### PR TITLE
Ollama AddOllamaSharpChatClient 메서드 deprecation 대응 #7

### DIFF
--- a/src/OpenChat.PlaygroundApp/Program.cs
+++ b/src/OpenChat.PlaygroundApp/Program.cs
@@ -32,7 +32,7 @@ if (config.LLM.ProviderType == LLMProviderType.OpenAI)
 // Add Ollama or Hugging Face
 if (config.LLM.ProviderType == LLMProviderType.Ollama || config.LLM.ProviderType == LLMProviderType.HuggingFace)
 {
-    builder.AddOllamaSharpChatClient(config.Ollama.DeploymentName);
+    builder.AddOllamaApiClient(config.Ollama.DeploymentName).AddChatClient();
 }
 
 var app = builder.Build();

--- a/src/OpenChat.PlaygroundApp/Program.cs
+++ b/src/OpenChat.PlaygroundApp/Program.cs
@@ -30,6 +30,10 @@ if (config.LLM.ProviderType == LLMProviderType.OpenAI)
 }
 
 // Add Ollama or Hugging Face
+// TODO : Except when deploying to azure
+// TODO : Cache model data volume
+// TODO : Service to use IOllamaClientApi
+// TODO : Q) Could we register Hface model with below logic? https://learn.microsoft.com/en-us/dotnet/aspire/community-toolkit/ollama?tabs=dotnet-cli%2Cdocker
 if (config.LLM.ProviderType == LLMProviderType.Ollama || config.LLM.ProviderType == LLMProviderType.HuggingFace)
 {
     builder.AddOllamaApiClient(config.Ollama.DeploymentName).AddChatClient();

--- a/test/OpenChat.PlaygroundApp.Tests/ProgramTest.cs
+++ b/test/OpenChat.PlaygroundApp.Tests/ProgramTest.cs
@@ -1,0 +1,80 @@
+namespace OpenChat.PlaygroundApp.Tests;
+
+using Xunit;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.AspNetCore.Builder;
+using System.Linq;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.AI;
+using OllamaSharp;
+using System.Threading.Tasks;
+
+public class ProgramTest
+{
+    /// <summary>
+    /// Ollama ChatClient DI Unit Test
+    /// </summary>
+    [Fact]
+    public void GivenBuilder_WhenOllamaRegisteredWithOldMethod_ThenItPersisted()
+    {
+        // Arrange
+        var builder = WebApplication.CreateBuilder();
+        string deploymentName = "llama"; // In prod, it reads config
+
+        // Act
+        builder.AddOllamaSharpChatClient(deploymentName);
+        var serviceProvider = builder.Services.BuildServiceProvider();
+
+        // Assert
+        var ollamaApiClient = serviceProvider.GetService(typeof(IOllamaApiClient));
+        var chatClient = serviceProvider.GetService(typeof(IChatClient));
+
+        Assert.NotNull(ollamaApiClient);
+        Assert.NotNull(chatClient);
+    }
+
+    /// <summary>
+    /// Ollama ChatClient DI Unit Test
+    /// </summary>
+    [Fact]
+    public void GivenBuilder_WhenOllamaRegistered_ThenItPersisted()
+    {
+        // Arrange
+        var builder = WebApplication.CreateBuilder();
+        string deploymentName = "http://localhost:11434"; // In prod, it reads config
+
+        // Act
+        builder.AddOllamaApiClient(deploymentName).AddChatClient();
+        var serviceProvider = builder.Services.BuildServiceProvider();
+
+        // Assert
+        var ollamaApiClient = serviceProvider.GetService(typeof(IOllamaApiClient));
+        var chatClient = serviceProvider.GetService(typeof(IChatClient));
+
+        Assert.NotNull(ollamaApiClient);
+        Assert.NotNull(chatClient);
+    }
+
+    /// <summary>
+    /// Ollama ChatClient Ollama model creation test
+    /// </summary>
+    [Fact]
+    public async Task GivenOllamaService_WhenOllamaModelRequested_ThenModelNotNull()
+    {
+        // Arrange
+        var builder = WebApplication.CreateBuilder();
+        string deploymentName = "llama"; // In prod, it reads config
+        builder.AddOllamaApiClient(deploymentName).AddChatClient();
+        var serviceProvider = builder.Services.BuildServiceProvider();
+
+        // Act
+        var ollamaApiClient = serviceProvider.GetService(typeof(IOllamaApiClient)) as IOllamaApiClient;
+        var chatClient = serviceProvider.GetService(typeof(IChatClient)) as IChatClient;
+
+        // Assert
+        Assert.NotNull(chatClient);
+        Assert.NotNull(ollamaApiClient);
+        var response = await chatClient.GetResponseAsync("Why is the sky blue?");
+        Console.WriteLine(response.Messages);
+    }
+}


### PR DESCRIPTION
#7 이슈 관련으로,
**deprecated된 Ollama 관련 메서드 변경하는 내용입니다.**
  
  
이 이슈와 별개로 다음 추가 이슈사항을 식별했으며
- Azure에 배포할 때 Ollama 의존성 추가 부분을 비활성화 필요
- OllamaSharp 패키지가 ApiClient 추가시에도 Hface 모델 지원하는지 명확하지 않음
- Ollama, Hface 모델 용량이 크니 패키지에서 제공하는 Cache 활용 필요
- IOllamaClientApi를 받는 Service 레이어 구현
  
  
의존성 주입, E2E 테스트는 추가로 확인이 필요합니다.