### PR TITLE
Add Playwright UI test samples for ChatInput components #16

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,3 +120,36 @@ This provides a web UI for AI chat playground that is able to connect virtually 
     ```
 
    > **NOTE**: You will be asked to provide Azure subscription and location for deployment.
+
+## Run Test
+
+1. Get the repository root.
+
+    ```bash
+    # bash/zsh
+    REPOSITORY_ROOT=$(git rev-parse --show-toplevel)
+    ```
+
+    ```powershell
+    # PowerShell
+    $REPOSITORY_ROOT = git rev-parse --show-toplevel
+    ```
+
+1. Restore packages and install playwright.
+
+    ```bash
+    cd $REPOSITORY_ROOT && dotnet restore
+    pwsh $REPOSITORY_ROOT/test/OpenChat.PlaygroundApp.Tests/bin/Debug/net{YOUR_VERSION}/playwright.ps1 install
+    ```
+
+1. Run the app.
+
+    ```bash
+    dotnet run --project $REPOSITORY_ROOT/src/OpenChat.PlaygroundApp
+    ```
+
+1. Run tests.
+
+    ```bash
+    cd $REPOSITORY_ROOT && dotnet test
+    ```

--- a/test/OpenChat.PlaygroundApp.Tests/Components/Pages/Chat/ChatInputUITests.cs
+++ b/test/OpenChat.PlaygroundApp.Tests/Components/Pages/Chat/ChatInputUITests.cs
@@ -1,0 +1,93 @@
+﻿using Microsoft.Playwright;
+using Microsoft.Playwright.Xunit;
+
+namespace OpenChat.PlaygroundApp.Tests.Components.Pages.Chat;
+
+public class ChatInputUITest : PageTest
+{
+    public override async Task InitializeAsync()
+    {
+        await base.InitializeAsync();
+        await Page.GotoAsync("http://localhost:8080");
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+    }
+
+    [Theory]
+    [InlineData("Why is the sky blue?")]
+    [InlineData(" ")]
+    [InlineData("\n")]
+    [InlineData("\n\r")]
+    public async Task GivenInputNotEmpty_WhenSendButtonClicked_ThenSend(string userMessage)
+    {
+        // Arrange
+        var textArea = Page.GetByRole(AriaRole.Textbox);
+        var sendButton = Page.GetByRole(AriaRole.Button, new() { Name = "Send" });
+        var messageCountBefore = await Page.Locator(".assistant-message-header")
+                                        .CountAsync();
+
+        // Act
+        await textArea.FillAsync(userMessage);
+        await sendButton.ClickAsync();
+
+        // Assert
+        await Expect(textArea).ToHaveValueAsync("");
+        await Expect(Page.Locator(".assistant-message-header"))
+                .ToHaveCountAsync(messageCountBefore + 1);
+    }
+
+    [Theory]
+    [InlineData("Why is the sky blue?")]
+    [InlineData(" ")]
+    [InlineData("\n")]
+    [InlineData("\n\r")]
+    public async Task GivenInputNotEmpty_ThenSendButtonColorShouldBeBlack(string userMessage)
+    {
+        // Arrange
+        var textArea = Page.GetByRole(AriaRole.Textbox);
+        var sendButton = Page.GetByRole(AriaRole.Button, new() { Name = "Send" });
+
+        // Act
+        await textArea.FillAsync(userMessage);
+
+        // Assert
+        await Expect(sendButton).ToHaveCSSAsync("color", "rgb(0, 0, 0)");
+    }
+
+    [Fact]
+    public async Task GivenInputEmpty_WhenSendButtonClicked_ThenDoNotSend()
+    {
+        // Arrange
+        var textArea = Page.GetByRole(AriaRole.Textbox);
+        var sendButton = Page.GetByRole(AriaRole.Button, new() { Name = "Send" });
+        var messageCountBefore = await Page.Locator(".assistant-message-header")
+                                        .CountAsync();
+
+        // Act
+        await textArea.FillAsync("");
+        await sendButton.ClickAsync();
+
+        // Assert
+        await Expect(Page.Locator(".assistant-message-header"))
+                .ToHaveCountAsync(messageCountBefore);
+    }
+
+    [Fact]
+    public async Task GivenInputEmpty_ThenButtonColorShouldBeGrey()
+    {
+        // Arrange
+        var textArea = Page.GetByRole(AriaRole.Textbox);
+        var sendButton = Page.GetByRole(AriaRole.Button, new() { Name = "Send" });
+
+        // Act
+        await textArea.FillAsync("");
+
+        // Assert
+        await Expect(sendButton).ToHaveCSSAsync("color", "rgb(170, 170, 170)");
+    }
+
+    public override async Task DisposeAsync()
+    {
+        await Page.CloseAsync();
+        await base.DisposeAsync();
+    }
+}


### PR DESCRIPTION
## 변경내용
1. README에 테스트 방법을 추가했습니다.
2. 질문 입력여부에 따라 버튼 색상이 잘 변경되는지 테스트 추가.
3. 질문 입력여부에 따라 버튼 클릭시 응답이 잘 생성되는지 테스트 추가.

## 질문사항
1. 테스트에서 UI 컴포넌트를 참조할 때 `data-testid`, HTML AriaRole, 그리고 CSS selector를 사용하는 방법들이 있는데, 그 중에 이번 프로젝트에서 가장 권장되는 방법이 무엇일까요?
2. 변경내용-3은 현재 팀 레포에 깃헙 토큰 설정이 되어 있지 않아 테스트가 실패합니다. 차후에 토큰 설정이 완료되면 반영하는 것이 나을까요?

## 추가 이슈사항
1. 변경내용-1에서 현재는 앱을 따로 기동해야만 테스트가 가능합니다. 나중에는 테스트시 자동으로 앱이 기동되도록 바꾸면 좋겠습니다.
2. 엔터를 눌러 질문을 보내는 부분도 테스트 추가가 필요할까요?