### PR TITLE
feat: introduce base language model connector abstractions

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,8 +15,7 @@ What kind of change does this Pull Request introduce?
 <!-- Please check the one that applies to this PR using "x". -->
 ```
 [ ] Bugfix
-[ ] New feature to existing sample
-[ ] New sample
+[ ] New feature
 [ ] Refactoring (no functional changes, no api changes)
 [ ] Documentation content changes
 [ ] Other... Please describe:

--- a/.github/workflows/azure-dev.yml
+++ b/.github/workflows/azure-dev.yml
@@ -9,8 +9,15 @@ on:
     - '.github/**'
 
 permissions:
-  id-token: write
   contents: read
+  packages: write
+  attestations: write
+  id-token: write
+
+env:
+  REGISTRY: ghcr.io
+  REPOSITORY: ${{ github.repository }}
+  IMAGE_NAME: openchat-playground
 
 jobs:
   build-test-deploy:
@@ -75,6 +82,40 @@ jobs:
       shell: bash
       run: |
         dotnet test . -c Release --no-build --logger "trx" --collect:"XPlat Code Coverage" --filter "Category=IntegrationTest & Category!=LLMRequired"
+
+    - name: Log in to the Container registry
+      uses: docker/login-action@v3
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Extract metadata (tags, labels) for Docker
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: ${{ env.REGISTRY }}/${{ env.REPOSITORY }}/${{ env.IMAGE_NAME }}
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Build and push Docker image
+      id: push
+      uses: docker/build-push-action@v6
+      with:
+        platforms: linux/amd64,linux/arm64
+        push: true
+        context: ${{ github.workspace }}
+        file: ${{ github.workspace }}/Dockerfile
+        tags: '${{ steps.meta.outputs.tags }},${{ env.REGISTRY }}/${{ env.REPOSITORY }}/${{ env.IMAGE_NAME }}:latest'
+        labels: ${{ steps.meta.outputs.labels }}
+
+    - name: Generate artifact attestation
+      uses: actions/attest-build-provenance@v2
+      with:
+        subject-name: ${{ env.REGISTRY }}/${{ env.REPOSITORY }}/${{ env.IMAGE_NAME }}
+        subject-digest: ${{ steps.push.outputs.digest }}
+        push-to-registry: true
 
     - name: Install azd
       uses: Azure/setup-azd@v2

--- a/Dockerfile.azure
+++ b/Dockerfile.azure
@@ -1,18 +1,12 @@
 # syntax=docker/dockerfile:1
 
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:9.0-alpine AS build
+FROM mcr.microsoft.com/dotnet/sdk:9.0-alpine AS build
 
 COPY ./src/OpenChat.PlaygroundApp /source/OpenChat.PlaygroundApp
 
 WORKDIR /source/OpenChat.PlaygroundApp
 
-ARG TARGETARCH
-RUN case "$TARGETARCH" in \
-      "amd64") RID="linux-musl-x64" ;; \
-      "arm64") RID="linux-musl-arm64" ;; \
-      *) RID="linux-musl-x64" ;; \
-    esac && \
-    dotnet publish -c Release -o /app -r $RID --self-contained false
+RUN dotnet publish -c Release -o /app
 
 FROM mcr.microsoft.com/dotnet/aspnet:9.0-alpine AS final
 

--- a/README.md
+++ b/README.md
@@ -111,12 +111,14 @@ This provides a web UI for AI chat playground that is able to connect virtually 
 
     ```bash
     # bash/zsh
-    TOKEN=$(dotnet user-secrets --project ./src/OpenChat.PlaygroundApp list --json | sed -n '/^\/\//d; p' | jq -r '."GitHubModels:Token"')
+    TOKEN=$(dotnet user-secrets --project ./src/OpenChat.PlaygroundApp list --json | \
+              sed -n '/^\/\//d; p' | jq -r '."GitHubModels:Token"')
     ```
 
     ```bash
     # PowerShell
-    $TOKEN = (dotnet user-secrets --project ./src/OpenChat.PlaygroundApp list --json | Select-String -NotMatch '^//(BEGIN|END)' | ConvertFrom-Json).'GitHubModels:Token'
+    $TOKEN = (dotnet user-secrets --project ./src/OpenChat.PlaygroundApp list --json | `
+                Select-String -NotMatch '^//(BEGIN|END)' | ConvertFrom-Json).'GitHubModels:Token'
     ```
 
 1. Run the app.
@@ -151,10 +153,16 @@ This provides a web UI for AI chat playground that is able to connect virtually 
 
 #### Unit tests
 
+1. Make sure you are at the repository root.
+
+    ```bash
+    cd $REPOSITORY_ROOT
+    ```
+
 1. Run tests.
 
     ```bash
-    cd $REPOSITORY_ROOT && dotnet test --filter "Category=UnitTest"
+    dotnet test --filter "Category=UnitTest"
     ```
 
 #### Integration tests

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This provides a web UI for AI chat playground that is able to connect virtually 
 - [Azure CLI](https://learn.microsoft.com/cli/azure/install-azure-cli) + [Container Apps extension](https://learn.microsoft.com/cli/azure/azure-cli-extensions-overview)
 - [GitHub CLI](https://cli.github.com/)
 
-## Getting Started
+## Getting started
 
 ### Get the repository ready
 
@@ -35,7 +35,11 @@ This provides a web UI for AI chat playground that is able to connect virtually 
     gh repo fork aliencube/open-chat-playground --clone --default-branch-only
     ```
 
-### Run on Local Machine
+1. Navigate to the cloned repository.
+
+    ```bash
+    cd open-chat-playground
+    ```
 
 1. Get the repository root.
 
@@ -47,6 +51,16 @@ This provides a web UI for AI chat playground that is able to connect virtually 
     ```powershell
     # PowerShell
     $REPOSITORY_ROOT = git rev-parse --show-toplevel
+    ```
+
+### Run on local machine
+
+#### Use GitHub Models
+
+1. Make sure you are at the repository root.
+
+    ```bash
+    cd $REPOSITORY_ROOT
     ```
 
 1. Add GitHub Personal Access Token (PAT) for GitHub Models connection. Make sure you should replace `{{YOUR_TOKEN}}` with your GitHub PAT.
@@ -68,24 +82,74 @@ This provides a web UI for AI chat playground that is able to connect virtually 
 1. Run the app.
 
     ```bash
-    dotnet run --project $REPOSITORY_ROOT/src/OpenChat.PlaygroundApp
+    dotnet run --project $REPOSITORY_ROOT/src/OpenChat.PlaygroundApp -- --connector-type GitHubModels
     ```
 
-1. Open your web browser and navigate to `http://localhost:8080` and enter prompts.
+1. Open your web browser, navigate to `http://localhost:5280`, and enter prompts.
 
-## Run Unit Tests
+### Run in container
 
-1. Get the repository root.
+#### Build container
+
+1. Make sure you are at the repository root.
+
+    ```bash
+    cd $REPOSITORY_ROOT
+    ```
+
+1. Build a container.
+
+    ```bash
+    docker build -f Dockerfile -t openchat-playground:latest .
+    ```
+
+#### Run container
+
+##### Use GitHub Models
+
+1. Get GitHub PAT.
 
     ```bash
     # bash/zsh
-    REPOSITORY_ROOT=$(git rev-parse --show-toplevel)
+    TOKEN=$(dotnet user-secrets --project ./src/OpenChat.PlaygroundApp list --json | sed -n '/^\/\//d; p' | jq -r '."GitHubModels:Token"')
     ```
 
-    ```powershell
+    ```bash
     # PowerShell
-    $REPOSITORY_ROOT = git rev-parse --show-toplevel
+    $TOKEN = (dotnet user-secrets --project ./src/OpenChat.PlaygroundApp list --json | Select-String -NotMatch '^//(BEGIN|END)' | ConvertFrom-Json).'GitHubModels:Token'
     ```
+
+1. Run the app.
+
+    ```bash
+    # From locally built container
+    docker run -i --rm -p 8080:8080 -e GitHubModels__Token=$TOKEN openchat-playground:latest --connector-type GitHubModels
+    ```
+
+    ```bash
+    # From GitHub Container Registry
+    docker run -i --rm -p 8080:8080 -e GitHubModels__Token=$TOKEN ghcr.io/aliencube/open-chat-playground/openchat-playground:latest --connector-type GitHubModels
+    ```
+
+1. Open your web browser, navigate to `http://localhost:8080`, and enter prompts.
+
+### Run tests
+
+#### Build app
+
+1. Make sure you are at the repository root.
+
+    ```bash
+    cd $REPOSITORY_ROOT
+    ```
+
+1. Build the app.
+
+    ```bash
+    dotnet restore && dotnet build
+    ```
+
+#### Unit tests
 
 1. Run tests.
 
@@ -93,24 +157,17 @@ This provides a web UI for AI chat playground that is able to connect virtually 
     cd $REPOSITORY_ROOT && dotnet test --filter "Category=UnitTest"
     ```
 
-## Run Integration Tests
+#### Integration tests
 
-1. Get the repository root.
-
-    ```bash
-    # bash/zsh
-    REPOSITORY_ROOT=$(git rev-parse --show-toplevel)
-    ```
-
-    ```powershell
-    # PowerShell
-    $REPOSITORY_ROOT = git rev-parse --show-toplevel
-    ```
-
-1. Restore packages and install playwright.
+1. Make sure you are at the repository root.
 
     ```bash
-    cd $REPOSITORY_ROOT && dotnet restore
+    cd $REPOSITORY_ROOT
+    ```
+
+1. Install playwright.
+
+    ```bash
     pwsh $REPOSITORY_ROOT/test/OpenChat.PlaygroundApp.Tests/bin/Debug/net{YOUR_VERSION}/playwright.ps1 install
     ```
 
@@ -124,27 +181,15 @@ This provides a web UI for AI chat playground that is able to connect virtually 
 
     ```bash
     # With LLM provider
-    cd $REPOSITORY_ROOT && dotnet test --filter "Category=IntegrationTest"
+    dotnet test --filter "Category=IntegrationTest"
     ```
 
     ```bash
     # Without LLM provider
-    cd $REPOSITORY_ROOT && dotnet test --filter "Category=IntegrationTest & Category!=LLMRequired"
+    dotnet test --filter "Category=IntegrationTest & Category!=LLMRequired"
     ```
 
 ### Run on Azure
-
-1. Get the repository root.
-
-    ```bash
-    # bash/zsh
-    REPOSITORY_ROOT=$(git rev-parse --show-toplevel)
-    ```
-
-    ```powershell
-    # PowerShell
-    $REPOSITORY_ROOT = git rev-parse --show-toplevel
-    ```
 
 1. Make sure you are at the repository root.
 
@@ -180,7 +225,13 @@ This provides a web UI for AI chat playground that is able to connect virtually 
 
    > **NOTE**: You will be asked to provide Azure subscription and location for deployment.
 
-## Configure GitHub Actions for CI/CD Pipeline
+### Configure GitHub Actions for CI/CD Pipeline
+
+1. Make sure you are at the repository root.
+
+    ```bash
+    cd $REPOSITORY_ROOT
+    ```
 
 1. Make sure you've logged in to Azure.
 

--- a/azure.yaml
+++ b/azure.yaml
@@ -11,7 +11,7 @@ services:
     host: containerapp
     language: dotnet
     docker:
-      path: ../../Dockerfile
+      path: ../../Dockerfile.azure
       context: ../../
       remoteBuild: true
 

--- a/src/OpenChat.PlaygroundApp/Abstractions/ArgumentOptions.cs
+++ b/src/OpenChat.PlaygroundApp/Abstractions/ArgumentOptions.cs
@@ -66,9 +66,9 @@ public abstract class ArgumentOptions
         var expectedName = connectorType + "ArgumentOptions";
 
         var assembly = typeof(ArgumentOptions).Assembly;
-        var optionsType = (assembly?.GetTypes()
+        var optionsType = assembly?.GetTypes()
                                    .SingleOrDefault(t => typeof(ArgumentOptions).IsAssignableFrom(t) &&
-                                                         string.Equals(t.Name, expectedName, StringComparison.InvariantCultureIgnoreCase)))
+                                                         string.Equals(t.Name, expectedName, StringComparison.InvariantCultureIgnoreCase))
                           ?? throw new InvalidOperationException($"Options type '{expectedName}' not found for connector type '{connectorType}'.");
 
         var options = (ArgumentOptions)Activator.CreateInstance(optionsType)!;
@@ -109,11 +109,26 @@ public abstract class ArgumentOptions
     /// <summary>
     /// Displays the help information for the command line arguments.
     /// </summary>
-    public void DisplayHelp()
+    public static void DisplayHelp()
     {
+        var foregroundColor = Console.ForegroundColor;
+
+        Console.ForegroundColor = ConsoleColor.Cyan;
+        Console.WriteLine("OpenChat Playground");
+        Console.ForegroundColor = foregroundColor;
+
         Console.WriteLine("Usage: [options]");
+        Console.WriteLine();
         Console.WriteLine("Options:");
-        Console.WriteLine("  --connector-type|-c  Specify the connector type.");
+        Console.WriteLine("  --connector-type|-c  The connector type. Supporting connectors are:");
+        Console.WriteLine("                       - AmazonBedrock, AzureAIFoundry, GitHubModels, GoogleVertexAI");
+        Console.WriteLine("                       - DockerModelRunner, FoundryLocal, HuggingFace, Ollama");
+        Console.WriteLine("                       - Anthropic, LG, Naver, OpenAI, Upstage");
+        Console.WriteLine("  ** GitHub Models: **");
+        Console.WriteLine("  --endpoint           The endpoint URL. Default to 'https://models.github.ai/inference'");
+        Console.WriteLine("  --token              The GitHub PAT.");
+        Console.WriteLine("  --model              The model name. Default to 'openai/gpt-5-mini'");
+        Console.WriteLine();
         Console.WriteLine("  --help|-h            Show this help message.");
     }
 

--- a/src/OpenChat.PlaygroundApp/Options/GitHubModelsArgumentOptions.cs
+++ b/src/OpenChat.PlaygroundApp/Options/GitHubModelsArgumentOptions.cs
@@ -7,4 +7,9 @@ namespace OpenChat.PlaygroundApp.Options;
 /// </summary>
 public class GitHubModelsArgumentOptions : ArgumentOptions
 {
+    /// <inheritdoc/>
+    protected override void ParseOptions(IConfiguration config, string[] args)
+    {
+        base.ParseOptions(config, args);
+    }
 }

--- a/src/OpenChat.PlaygroundApp/Program.cs
+++ b/src/OpenChat.PlaygroundApp/Program.cs
@@ -5,24 +5,35 @@ using Microsoft.Extensions.AI;
 using OpenChat.PlaygroundApp.Components;
 
 using OpenAI;
+using OpenChat.PlaygroundApp.Abstractions;
 
 var builder = WebApplication.CreateBuilder(args);
+
+var config = builder.Configuration;
+var settings = ArgumentOptions.Parse(config, args);
+if (settings.Help == true)
+{
+    ArgumentOptions.DisplayHelp();
+    return;
+}
 
 builder.Services.AddRazorComponents()
                 .AddInteractiveServerComponents();
 
-// You will need to set the endpoint and key to your own values
-// You can do this using Visual Studio's "Manage User Secrets" UI, or on the command line:
-//   cd this-project-directory
-//   dotnet user-secrets set GitHubModels:Token YOUR-GITHUB-TOKEN
-var credential = new ApiKeyCredential(builder.Configuration["GitHubModels:Token"] ?? throw new InvalidOperationException("Missing configuration: GitHubModels:Token. See the README for details."));
-var openAIOptions = new OpenAIClientOptions()
-{
-    Endpoint = new Uri("https://models.github.ai/inference")
-};
+var chatClient = LanguageModelConnector.CreateChatClient(settings);
 
-var ghModelsClient = new OpenAIClient(credential, openAIOptions);
-var chatClient = ghModelsClient.GetChatClient("openai/gpt-4o").AsIChatClient();
+// // You will need to set the endpoint and key to your own values
+// // You can do this using Visual Studio's "Manage User Secrets" UI, or on the command line:
+// //   cd this-project-directory
+// //   dotnet user-secrets set GitHubModels:Token YOUR-GITHUB-TOKEN
+// var credential = new ApiKeyCredential(builder.Configuration["GitHubModels:Token"] ?? throw new InvalidOperationException("Missing configuration: GitHubModels:Token. See the README for details."));
+// var openAIOptions = new OpenAIClientOptions()
+// {
+//     Endpoint = new Uri("https://models.github.ai/inference")
+// };
+
+// var ghModelsClient = new OpenAIClient(credential, openAIOptions);
+// var chatClient = ghModelsClient.GetChatClient("openai/gpt-4o").AsIChatClient();
 
 builder.Services.AddChatClient(chatClient)
                 .UseFunctionInvocation()

--- a/src/OpenChat.PlaygroundApp/Program.cs
+++ b/src/OpenChat.PlaygroundApp/Program.cs
@@ -1,11 +1,7 @@
-using System.ClientModel;
-
 using Microsoft.Extensions.AI;
 
-using OpenChat.PlaygroundApp.Components;
-
-using OpenAI;
 using OpenChat.PlaygroundApp.Abstractions;
+using OpenChat.PlaygroundApp.Components;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -21,19 +17,6 @@ builder.Services.AddRazorComponents()
                 .AddInteractiveServerComponents();
 
 var chatClient = LanguageModelConnector.CreateChatClient(settings);
-
-// // You will need to set the endpoint and key to your own values
-// // You can do this using Visual Studio's "Manage User Secrets" UI, or on the command line:
-// //   cd this-project-directory
-// //   dotnet user-secrets set GitHubModels:Token YOUR-GITHUB-TOKEN
-// var credential = new ApiKeyCredential(builder.Configuration["GitHubModels:Token"] ?? throw new InvalidOperationException("Missing configuration: GitHubModels:Token. See the README for details."));
-// var openAIOptions = new OpenAIClientOptions()
-// {
-//     Endpoint = new Uri("https://models.github.ai/inference")
-// };
-
-// var ghModelsClient = new OpenAIClient(credential, openAIOptions);
-// var chatClient = ghModelsClient.GetChatClient("openai/gpt-4o").AsIChatClient();
 
 builder.Services.AddChatClient(chatClient)
                 .UseFunctionInvocation()

--- a/test/OpenChat.PlaygroundApp.Tests/Abstractions/ArgumentOptionsTests.cs
+++ b/test/OpenChat.PlaygroundApp.Tests/Abstractions/ArgumentOptionsTests.cs
@@ -99,6 +99,19 @@ public class ArgumentOptionsTests
     }
 
     [Trait("Category", "UnitTest")]
+    [Theory]
+    [InlineData("ConnectorType", "GoogleVertexAI")]
+    public void Given_Unimplemented_ConnectorType_When_Parse_Invoked_Then_It_Should_Throw(string key, string value)
+    {
+        var config = BuildConfig((key, value));
+        var args = Array.Empty<string>();
+
+        var ex = Assert.Throws<InvalidOperationException>(() => ArgumentOptions.Parse(config, args));
+
+        ex.Message.ShouldContain($"{value}ArgumentOptions");
+    }
+
+    [Trait("Category", "UnitTest")]
     [Fact]
     public void Given_Empty_ConnectorType_When_Parse_Invoked_Then_It_Should_Return_Unknown()
     {

--- a/test/OpenChat.PlaygroundApp.Tests/Connectors/GitHubModelsConnectorTests.cs
+++ b/test/OpenChat.PlaygroundApp.Tests/Connectors/GitHubModelsConnectorTests.cs
@@ -31,39 +31,45 @@ public class GitHubModelsConnectorTests
 		client.ShouldNotBeNull();
 	}
 
+    [Trait("Category", "UnitTest")]
+    [Theory]
+    [InlineData(null, typeof(InvalidOperationException), "GitHubModels:Token")]
+    [InlineData("", typeof(ArgumentException), "key")]
+	public void Given_Missing_Token_When_GetChatClient_Invoked_Then_It_Should_Throw(string? token, Type expected, string message)
+    {
+        var settings = BuildAppSettings(token: token);
+        var connector = new GitHubModelsConnector(settings);
+
+        var ex = Assert.Throws(expected, connector.GetChatClient);
+
+        ex.Message.ShouldContain(message);
+    }
+
 	[Trait("Category", "UnitTest")]
-	[Fact]
-	public void Given_Missing_Token_When_GetChatClient_Invoked_Then_It_Should_Throw()
+    [Theory]
+    [InlineData(null, typeof(InvalidOperationException), "GitHubModels:Endpoint")]
+    [InlineData("", typeof(UriFormatException), "empty")]
+	public void Given_Missing_Endpoint_When_GetChatClient_Invoked_Then_It_Should_Throw(string? endpoint, Type expected, string message)
 	{
-		var settings = BuildAppSettings(token: null);
+		var settings = BuildAppSettings(endpoint: endpoint);
 		var connector = new GitHubModelsConnector(settings);
 
-		var ex = Assert.Throws<InvalidOperationException>(() => connector.GetChatClient());
+		var ex = Assert.Throws(expected, connector.GetChatClient);
 
-		ex.Message.ShouldContain("GitHubModels:Token");
+		ex.Message.ShouldContain(message);
 	}
 
 	[Trait("Category", "UnitTest")]
-	[Fact]
-	public void Given_Missing_Endpoint_When_GetChatClient_Invoked_Then_It_Should_Throw()
+    [Theory]
+    [InlineData(null, typeof(ArgumentNullException), "model")]
+    [InlineData("", typeof(ArgumentException), "model")]
+	public void Given_Missing_Model_When_GetChatClient_Invoked_Then_It_Should_Throw(string? model, Type expected, string message)
 	{
-		var settings = BuildAppSettings(endpoint: null);
+		var settings = BuildAppSettings(model: model);
 		var connector = new GitHubModelsConnector(settings);
 
-		var ex = Assert.Throws<InvalidOperationException>(() => connector.GetChatClient());
+		var ex = Assert.Throws(expected, connector.GetChatClient);
 
-		ex.Message.ShouldContain("GitHubModels:Endpoint");
-	}
-
-	[Trait("Category", "UnitTest")]
-	[Fact]
-	public void Given_Missing_Model_When_GetChatClient_Invoked_Then_It_Should_Throw()
-	{
-		var settings = BuildAppSettings(model: null);
-		var connector = new GitHubModelsConnector(settings);
-
-		var ex = Assert.Throws<ArgumentNullException>(() => connector.GetChatClient());
-
-		ex.ParamName.ShouldBe("model");
+		ex.Message.ShouldContain(message);
 	}
 }


### PR DESCRIPTION
## Purpose
### Summary
Follow-on integration after the foundational abstraction in PR #204. Whereas #204 created the `BaseConnector` abstraction and factory pattern, this PR operationalizes it inside the application and delivers the first concrete provider wiring plus multi-provider option scaffolding.

### Related Work / Context
- PR #204 established the extensibility shell (virtual methods, factory pattern) for connectors.
- User story / feature needs from issues #195 and #188 defined the overridable contract & base implementation.
- This PR integrates that shell into runtime DI & configuration (issue #215) and begins real provider enablement.

### Key Changes
- DI + configuration binding for connector abstractions so providers are resolved at runtime.
- Unified argument option records for: Azure AI Foundry, OpenAI, GitHub Models, Amazon Bedrock, Foundry Local.
- Initial GitHub Models connector implementation exercising `GetChatClient` and base virtual hooks.
- Normalized settings / model selection logic reducing per‑provider boilerplate.
- Prepares chat UI/backend to toggle or add providers with minimal incremental code.

### Motivation
Enable rapid addition of new model providers with a consistent contract, reducing duplication and paving the way for future cross‑cutting concerns (telemetry, capability negotiation, retries, streaming) without refactoring each provider.

### Implementation Notes
- Keeps provider-specific logic thin; shared behavior lives in the base abstraction.
- Options records intentionally mirror each provider's canonical configuration while converging naming patterns.
- Leaves extension points (virtual methods) untouched to allow later enhancements like streaming token pipelines or telemetry.

### Testing
Initial set:
- Existing unit tests validating abstraction behavior from PR #204.
- New coverage exercising connector option binding & basic instantiation (GitHub Models path).
- Manual smoke: build, run, open chat UI, select/configure GitHub Models connector (no runtime errors).

Updated (post-review additions):
- Added ArgumentOptionsReflectionTests: verifies Parse throws when a connector enum (e.g. GoogleVertexAI) lacks a corresponding *ArgumentOptions type (guards reflection path).
- Added GitHubModelsConnectorEdgeCaseTests: missing settings section, blank endpoint, blank model edge cases (extends existing null tests).
- Integration (Playwright) tests: currently require the app to be running; CI workflow starts the app before running non-LLMRequired tests. Local ad-hoc 'dotnet test' without hosting will see Playwright connection failures (expected). A future refinement may introduce a test server fixture.

### Follow Ups (Out of Scope)
- Additional concrete connectors (Azure AI Foundry, OpenAI, Bedrock, Local) implementations.
- Enhanced telemetry / logging & token streaming pipeline.
- Retry, resilience policies, and capability negotiation service.
- Documentation for configuring each provider + secrets guidance.
- Test server fixture to remove manual pre-run for Playwright tests.

### Issues Closed
Closes #215
Closes #195
Closes #188

## Does this introduce a breaking change?
```
[ ] Yes
[x] No
```

## Pull Request Type
```
[ ] Bugfix
[x] New feature to existing sample
[ ] New sample
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## README updated?
```
[ ] Yes
[ ] No
[x] N/A
```

## How to Test
* Get the code
```
git clone https://github.com/aliencube/open-chat-playground.git
cd open-chat-playground
git checkout feat/connector
```

* Build & run tests
```
dotnet build
dotnet test -c Release --filter "Category=UnitTest"
```

* (Optional) Run integration tests
1. Start the app: `dotnet run --project src/OpenChat.PlaygroundApp` (ensure GitHubModels token configured via user-secrets or env var)  
2. In another shell: `dotnet test -c Release --filter "Category=IntegrationTest & Category!=LLMRequired"`

* Run the playground (development)
```
dotnet run --project src/OpenChat.PlaygroundApp
```

(Optionally provide provider credentials via user secrets or environment variables as per upcoming docs.)

## What to Check
Verify that:
* Project builds successfully targeting net9.0.
* Unit tests pass (`Category=UnitTest`).
* Integration tests pass when app is hosted.
* Application starts and loads the chat UI.
* GitHub Models connector can be selected/configured (where applicable) without runtime errors.
* No regressions in existing chat functionality.

## Other Information
* Establishes a consistent pattern for future connectors (single options + settings + connector implementation).
* No behavioral changes to existing UI beyond new underlying abstractions.
* Follow-up PRs will add additional provider-specific connectors & documentation.
