### PR TITLE
Update `LanguageModelConnector.CreateChatClientAsync(...)` to be `async`/`await`

### DIFF
--- a/src/OpenChat.PlaygroundApp/Abstractions/ArgumentOptions.cs
+++ b/src/OpenChat.PlaygroundApp/Abstractions/ArgumentOptions.cs
@@ -9,14 +9,14 @@ namespace OpenChat.PlaygroundApp.Abstractions;
 /// </summary>
 public abstract class ArgumentOptions
 {
-    private static readonly (string Argument, bool IsSwitch)[] arguments =
+    private static readonly (ConnectorType ConnectorType,string Argument, bool IsSwitch)[] arguments =
     [
         // Amazon Bedrock
         // Azure AI Foundry
         // GitHub Models
-        ("--endpoint", false),
-        ("--token", false),
-        ("--model", false)
+        (ConnectorType.GitHubModels, "--endpoint", false),
+        (ConnectorType.GitHubModels, "--token", false),
+        (ConnectorType.GitHubModels, "--model", false)
         // Google Vertex AI
         // Docker Model Runner
         // Foundry Local
@@ -118,7 +118,8 @@ public abstract class ArgumentOptions
                     break;
 
                 default:
-                    var argument = arguments.SingleOrDefault(p => p.Argument.Equals(args[i], StringComparison.InvariantCultureIgnoreCase));
+                    var argument = arguments.SingleOrDefault(p => p.ConnectorType == connectorType &&
+                                                                  p.Argument.Equals(args[i], StringComparison.InvariantCultureIgnoreCase));
                     if (argument == default)
                     {
                         options.Help = true;
@@ -138,6 +139,9 @@ public abstract class ArgumentOptions
                 settings.GitHubModels.Endpoint = github.Endpoint ?? settings.GitHubModels.Endpoint;
                 settings.GitHubModels.Token = github.Token ?? settings.GitHubModels.Token;
                 settings.GitHubModels.Model = github.Model ?? settings.GitHubModels.Model;
+                break;
+
+            default:
                 break;
         }
 

--- a/src/OpenChat.PlaygroundApp/Abstractions/LanguageModelConnector.cs
+++ b/src/OpenChat.PlaygroundApp/Abstractions/LanguageModelConnector.cs
@@ -19,14 +19,14 @@ public abstract class LanguageModelConnector(LanguageModelSettings? settings)
     /// Gets an <see cref="IChatClient"/> instance.
     /// </summary>
     /// <returns>Returns <see cref="IChatClient"/> instance.</returns>
-    public abstract IChatClient GetChatClient();
+    public abstract Task<IChatClient> GetChatClientAsync();
 
     /// <summary>
     /// Gets an <see cref="IChatClient"/> instance based on the app settings provided.
     /// </summary>
     /// <param name="settings"><see cref="AppSettings"/> instance.</param>
     /// <returns>Returns <see cref="IChatClient"/> instance.</returns>
-    public static IChatClient CreateChatClient(AppSettings settings)
+    public static async Task<IChatClient> CreateChatClientAsync(AppSettings settings)
     {
         LanguageModelConnector connector = settings.ConnectorType switch
         {
@@ -34,6 +34,6 @@ public abstract class LanguageModelConnector(LanguageModelSettings? settings)
             _ => throw new NotSupportedException($"Connector type '{settings.ConnectorType}' is not supported.")
         };
 
-        return connector.GetChatClient();
+        return await connector.GetChatClientAsync().ConfigureAwait(false);
     }
 }

--- a/src/OpenChat.PlaygroundApp/Connectors/GitHubModelsConnector.cs
+++ b/src/OpenChat.PlaygroundApp/Connectors/GitHubModelsConnector.cs
@@ -9,10 +9,13 @@ using OpenChat.PlaygroundApp.Configurations;
 
 namespace OpenChat.PlaygroundApp.Connectors;
 
+/// <summary>
+/// This represents the connector entity for GitHub Models.
+/// </summary>
 public class GitHubModelsConnector(AppSettings settings) : LanguageModelConnector(settings.GitHubModels)
 {
     /// <inheritdoc/>
-    public override IChatClient GetChatClient()
+    public override async Task<IChatClient> GetChatClientAsync()
     {
         var settings = this.Settings as GitHubModelsSettings;
 
@@ -26,6 +29,6 @@ public class GitHubModelsConnector(AppSettings settings) : LanguageModelConnecto
         var chatClient = client.GetChatClient(settings.Model)
                                .AsIChatClient();
 
-        return chatClient;
+        return await Task.FromResult(chatClient).ConfigureAwait(false);
     }
 }

--- a/src/OpenChat.PlaygroundApp/Program.cs
+++ b/src/OpenChat.PlaygroundApp/Program.cs
@@ -16,7 +16,7 @@ if (settings.Help == true)
 builder.Services.AddRazorComponents()
                 .AddInteractiveServerComponents();
 
-var chatClient = LanguageModelConnector.CreateChatClient(settings);
+var chatClient = await LanguageModelConnector.CreateChatClientAsync(settings);
 
 builder.Services.AddChatClient(chatClient)
                 .UseFunctionInvocation()
@@ -40,4 +40,4 @@ app.UseStaticFiles();
 app.MapRazorComponents<App>()
    .AddInteractiveServerRenderMode();
 
-app.Run();
+await app.RunAsync();

--- a/test/OpenChat.PlaygroundApp.Tests/Abstractions/LanguageModelConnectorTests.cs
+++ b/test/OpenChat.PlaygroundApp.Tests/Abstractions/LanguageModelConnectorTests.cs
@@ -26,10 +26,10 @@ public class LanguageModelConnectorTests
 
 	[Trait("Category", "UnitTest")]
 	[Fact]
-	public void Given_GitHubModels_Settings_When_CreateChatClient_Invoked_Then_It_Should_Return_ChatClient()
+	public async Task Given_GitHubModels_Settings_When_CreateChatClient_Invoked_Then_It_Should_Return_ChatClient()
 	{
 		var settings = BuildAppSettings();
-		var client = LanguageModelConnector.CreateChatClient(settings);
+		var client = await LanguageModelConnector.CreateChatClientAsync(settings);
 
 		client.ShouldNotBeNull();
 	}
@@ -40,11 +40,11 @@ public class LanguageModelConnectorTests
 	[InlineData(ConnectorType.AmazonBedrock)]
 	[InlineData(ConnectorType.AzureAIFoundry)]
 	[InlineData(ConnectorType.Unknown)]
-	public void Given_Unsupported_ConnectorType_When_CreateChatClient_Invoked_Then_It_Should_Throw(ConnectorType connectorType)
+	public async Task Given_Unsupported_ConnectorType_When_CreateChatClient_Invoked_Then_It_Should_Throw(ConnectorType connectorType)
 	{
 		var settings = BuildAppSettings(connectorType: connectorType);
 
-		var ex = Assert.Throws<NotSupportedException>(() => LanguageModelConnector.CreateChatClient(settings));
+		var ex = await Assert.ThrowsAsync<NotSupportedException>(() => LanguageModelConnector.CreateChatClientAsync(settings));
 
 		ex.Message.ShouldContain($"Connector type '{connectorType}'");
 	}

--- a/test/OpenChat.PlaygroundApp.Tests/Connectors/GitHubModelsConnectorTests.cs
+++ b/test/OpenChat.PlaygroundApp.Tests/Connectors/GitHubModelsConnectorTests.cs
@@ -21,12 +21,12 @@ public class GitHubModelsConnectorTests
 
 	[Trait("Category", "UnitTest")]
 	[Fact]
-	public void Given_Valid_Settings_When_GetChatClient_Invoked_Then_It_Should_Return_ChatClient()
+	public async Task Given_Valid_Settings_When_GetChatClient_Invoked_Then_It_Should_Return_ChatClient()
 	{
 		var settings = BuildAppSettings();
 		var connector = new GitHubModelsConnector(settings);
 
-		var client = connector.GetChatClient();
+		var client = await connector.GetChatClientAsync();
 
 		client.ShouldNotBeNull();
 	}
@@ -35,12 +35,12 @@ public class GitHubModelsConnectorTests
     [Theory]
     [InlineData(null, typeof(InvalidOperationException), "GitHubModels:Token")]
     [InlineData("", typeof(ArgumentException), "key")]
-	public void Given_Missing_Token_When_GetChatClient_Invoked_Then_It_Should_Throw(string? token, Type expected, string message)
+	public async Task Given_Missing_Token_When_GetChatClient_Invoked_Then_It_Should_Throw(string? token, Type expected, string message)
     {
         var settings = BuildAppSettings(token: token);
         var connector = new GitHubModelsConnector(settings);
 
-        var ex = Assert.Throws(expected, connector.GetChatClient);
+        var ex = await Assert.ThrowsAsync(expected, connector.GetChatClientAsync);
 
         ex.Message.ShouldContain(message);
     }
@@ -49,12 +49,12 @@ public class GitHubModelsConnectorTests
     [Theory]
     [InlineData(null, typeof(InvalidOperationException), "GitHubModels:Endpoint")]
     [InlineData("", typeof(UriFormatException), "empty")]
-	public void Given_Missing_Endpoint_When_GetChatClient_Invoked_Then_It_Should_Throw(string? endpoint, Type expected, string message)
+	public async Task Given_Missing_Endpoint_When_GetChatClient_Invoked_Then_It_Should_Throw(string? endpoint, Type expected, string message)
 	{
 		var settings = BuildAppSettings(endpoint: endpoint);
 		var connector = new GitHubModelsConnector(settings);
 
-		var ex = Assert.Throws(expected, connector.GetChatClient);
+		var ex = await Assert.ThrowsAsync(expected, connector.GetChatClientAsync);
 
 		ex.Message.ShouldContain(message);
 	}
@@ -63,12 +63,12 @@ public class GitHubModelsConnectorTests
     [Theory]
     [InlineData(null, typeof(ArgumentNullException), "model")]
     [InlineData("", typeof(ArgumentException), "model")]
-	public void Given_Missing_Model_When_GetChatClient_Invoked_Then_It_Should_Throw(string? model, Type expected, string message)
+	public async Task Given_Missing_Model_When_GetChatClient_Invoked_Then_It_Should_Throw(string? model, Type expected, string message)
 	{
 		var settings = BuildAppSettings(model: model);
 		var connector = new GitHubModelsConnector(settings);
 
-		var ex = Assert.Throws(expected, connector.GetChatClient);
+		var ex = await Assert.ThrowsAsync(expected, connector.GetChatClientAsync);
 
 		ex.Message.ShouldContain(message);
 	}


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Close #359 
* Some connectors need `async`/`await` capability, while the current `LanguageModelConnector.CreateChatClient(...)` doesn't.
  * This PR updates the method to allow `async`/`await` capabilities.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[x] Yes
[ ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] New feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## README updated?

The top-level readme for this repo contains a link to each sample in the repo. If you're adding a new sample did you update the readme?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
[ ] N/A
```

## How to Test
*  Get the code

```
git clone https://github.com/aliencube/open-chat-playground.git
cd open-chat-playground
git checkout hotfix/359-connector-factory
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
dotnet test --filter "Category=UnitTest"
```

## What to Check
Verify that the following are valid
* All tests passes
