### PR TITLE
feat: implement UpstageSolarSettings model class for Issue #233

### DIFF
--- a/src/OpenChat.PlaygroundApp/Configurations/UpstageSolarSettings.cs
+++ b/src/OpenChat.PlaygroundApp/Configurations/UpstageSolarSettings.cs
@@ -1,0 +1,33 @@
+using OpenChat.PlaygroundApp.Abstractions;
+
+namespace OpenChat.PlaygroundApp.Configurations;
+
+/// <inheritdoc/>
+public partial class AppSettings
+{
+    /// <summary>
+    /// Gets or sets the <see cref="UpstageSolarSettings"/> instance.
+    /// </summary>
+    public UpstageSolarSettings? Upstage { get; set; }
+}
+
+/// <summary>
+/// This represents the app settings entity for Upstage Solar.
+/// </summary>
+public class UpstageSolarSettings : LanguageModelSettings
+{
+    /// <summary>
+    /// Gets or sets the base URL of Upstage Solar API.
+    /// </summary>
+    public string? BaseUrl { get; set; }
+
+    /// <summary>
+    /// Gets or sets the Upstage API key.
+    /// </summary>
+    public string? ApiKey { get; set; }
+
+    /// <summary>
+    /// Gets or sets the model name of Upstage Solar.
+    /// </summary>
+    public string? Model { get; set; }
+}


### PR DESCRIPTION
## Purpose
* Implement UpstageSolarSettings model class to represent the Upstage Solar API configuration section in appsettings.json
* Provide type-safe access to Upstage Solar configuration settings
* Enable dependency injection of Upstage Solar settings throughout the application
* Follow the established architectural pattern used by other language model providers

## Does this introduce a breaking change?


## Pull Request Type
What kind of change does this Pull Request introduce?


## README updated?


## How to Test
* Get the code
branch 'feature/233-upstage-model-class' set up to track 'origin/feature/233-upstage-model-class'.

* Test the code
  Determining projects to restore...
  All projects are up-to-date for restore.
  OpenChat.PlaygroundApp -> /Users/gremh/src/open-chat-playground/src/OpenChat.PlaygroundApp/bin/Debug/net9.0/OpenChat.PlaygroundApp.dll
  OpenChat.PlaygroundApp.Tests -> /Users/gremh/src/open-chat-playground/test/OpenChat.PlaygroundApp.Tests/bin/Debug/net9.0/OpenChat.PlaygroundApp.Tests.dll

Build succeeded.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:00:07.66
  Determining projects to restore...
  All projects are up-to-date for restore.
  OpenChat.PlaygroundApp -> /Users/gremh/src/open-chat-playground/src/OpenChat.PlaygroundApp/bin/Debug/net9.0/OpenChat.PlaygroundApp.dll
  OpenChat.PlaygroundApp.Tests -> /Users/gremh/src/open-chat-playground/test/OpenChat.PlaygroundApp.Tests/bin/Debug/net9.0/OpenChat.PlaygroundApp.Tests.dll
Test run for /Users/gremh/src/open-chat-playground/test/OpenChat.PlaygroundApp.Tests/bin/Debug/net9.0/OpenChat.PlaygroundApp.Tests.dll (.NETCoreApp,Version=v9.0)
VSTest version 17.14.1 (arm64)

Starting test execution, please wait...
A total of 1 test files matched the specified pattern.
  Failed OpenChat.PlaygroundApp.Tests.Components.Pages.Chat.ChatHeaderUITests.Given_Root_Page_When_Loaded_Then_Header_Should_Be_Visible(expected: "OpenChat.PlaygroundApp") [1 ms]
  Error Message:
   Microsoft.Playwright.PlaywrightException : Executable doesn't exist at /Users/gremh/Library/Caches/ms-playwright/chromium_headless_shell-1181/chrome-mac/headless_shell
╔════════════════════════════════════════════════════════════╗
║ Looks like Playwright was just installed or updated.       ║
║ Please run the following command to download new browsers: ║
║                                                            ║
║     pwsh bin/Debug/netX/playwright.ps1 install             ║
║                                                            ║
║ <3 Playwright Team                                         ║
╚════════════════════════════════════════════════════════════╝
  Stack Trace:
     at Microsoft.Playwright.Transport.Connection.InnerSendMessageToServerAsync[T](ChannelOwner object, String method, Dictionary`2 dictionary, Boolean keepNulls) in /_/src/Playwright/Transport/Connection.cs:line 201
   at Microsoft.Playwright.Transport.Connection.WrapApiCallAsync[T](Func`1 action, Boolean isInternal, String title) in /_/src/Playwright/Transport/Connection.cs:line 499
   at Microsoft.Playwright.Core.BrowserType.LaunchAsync(BrowserTypeLaunchOptions options) in /_/src/Playwright/Core/BrowserType.cs:line 56
   at Microsoft.Playwright.Xunit.BrowserService.CreateBrowser(IBrowserType browserType, Nullable`1 connectOptions) in /_/src/Playwright.Xunit/BrowserService.cs:line 66
   at Microsoft.Playwright.Xunit.BrowserService.<>c__DisplayClass5_0.<<Register>b__0>d.MoveNext() in /_/src/Playwright.Xunit/BrowserService.cs:line 47
--- End of stack trace from previous location ---
   at Microsoft.Playwright.Xunit.WorkerAwareTest.RegisterService[T](String name, Func`1 factory) in /_/src/Playwright.Xunit/WorkerAwareTest.cs:line 54
   at Microsoft.Playwright.Xunit.BrowserTest.InitializeAsync() in /_/src/Playwright.Xunit/BrowserTest.cs:line 45
   at Microsoft.Playwright.Xunit.ContextTest.InitializeAsync() in /_/src/Playwright.Xunit/ContextTest.cs:line 35
   at Microsoft.Playwright.Xunit.PageTest.InitializeAsync() in /_/src/Playwright.Xunit/PageTest.cs:line 35
   at OpenChat.PlaygroundApp.Tests.Components.Pages.Chat.ChatHeaderUITests.InitializeAsync() in /Users/gremh/src/open-chat-playground/test/OpenChat.PlaygroundApp.Tests/Components/Pages/Chat/ChatHeaderUITests.cs:line 10
  Failed OpenChat.PlaygroundApp.Tests.Components.Pages.Chat.ChatInputUITest.Given_UserMessage_When_TextArea_FilledIn_Then_It_Should_Change_Color_Of_SendButton(userMessage: "하늘은 왜 푸를까?", expectedButtonColor: "rgb(0, 0, 0)") [1 ms]
  Error Message:
   Microsoft.Playwright.PlaywrightException : Executable doesn't exist at /Users/gremh/Library/Caches/ms-playwright/chromium_headless_shell-1181/chrome-mac/headless_shell
╔════════════════════════════════════════════════════════════╗
║ Looks like Playwright was just installed or updated.       ║
║ Please run the following command to download new browsers: ║
║                                                            ║
║     pwsh bin/Debug/netX/playwright.ps1 install             ║
║                                                            ║
║ <3 Playwright Team                                         ║
╚════════════════════════════════════════════════════════════╝
  Stack Trace:
     at Microsoft.Playwright.Transport.Connection.InnerSendMessageToServerAsync[T](ChannelOwner object, String method, Dictionary`2 dictionary, Boolean keepNulls) in /_/src/Playwright/Transport/Connection.cs:line 201
   at Microsoft.Playwright.Transport.Connection.WrapApiCallAsync[T](Func`1 action, Boolean isInternal, String title) in /_/src/Playwright/Transport/Connection.cs:line 499
   at Microsoft.Playwright.Core.BrowserType.LaunchAsync(BrowserTypeLaunchOptions options) in /_/src/Playwright/Core/BrowserType.cs:line 56
   at Microsoft.Playwright.Xunit.BrowserService.CreateBrowser(IBrowserType browserType, Nullable`1 connectOptions) in /_/src/Playwright.Xunit/BrowserService.cs:line 66
   at Microsoft.Playwright.Xunit.BrowserService.<>c__DisplayClass5_0.<<Register>b__0>d.MoveNext() in /_/src/Playwright.Xunit/BrowserService.cs:line 47
--- End of stack trace from previous location ---
   at Microsoft.Playwright.Xunit.WorkerAwareTest.RegisterService[T](String name, Func`1 factory) in /_/src/Playwright.Xunit/WorkerAwareTest.cs:line 54
   at Microsoft.Playwright.Xunit.BrowserTest.InitializeAsync() in /_/src/Playwright.Xunit/BrowserTest.cs:line 45
   at Microsoft.Playwright.Xunit.ContextTest.InitializeAsync() in /_/src/Playwright.Xunit/ContextTest.cs:line 35
   at Microsoft.Playwright.Xunit.PageTest.InitializeAsync() in /_/src/Playwright.Xunit/PageTest.cs:line 35
   at OpenChat.PlaygroundApp.Tests.Components.Pages.Chat.ChatInputUITest.InitializeAsync() in /Users/gremh/src/open-chat-playground/test/OpenChat.PlaygroundApp.Tests/Components/Pages/Chat/ChatInputUITests.cs:line 10
  Failed OpenChat.PlaygroundApp.Tests.Components.Pages.Chat.ChatInputUITest.Given_UserMessage_When_TextArea_FilledIn_Then_It_Should_Change_Color_Of_SendButton(userMessage: "Why is the sky blue?", expectedButtonColor: "rgb(0, 0, 0)") [1 ms]
  Error Message:
   Microsoft.Playwright.PlaywrightException : Executable doesn't exist at /Users/gremh/Library/Caches/ms-playwright/chromium_headless_shell-1181/chrome-mac/headless_shell
╔════════════════════════════════════════════════════════════╗
║ Looks like Playwright was just installed or updated.       ║
║ Please run the following command to download new browsers: ║
║                                                            ║
║     pwsh bin/Debug/netX/playwright.ps1 install             ║
║                                                            ║
║ <3 Playwright Team                                         ║
╚════════════════════════════════════════════════════════════╝
  Stack Trace:
     at Microsoft.Playwright.Transport.Connection.InnerSendMessageToServerAsync[T](ChannelOwner object, String method, Dictionary`2 dictionary, Boolean keepNulls) in /_/src/Playwright/Transport/Connection.cs:line 201
   at Microsoft.Playwright.Transport.Connection.WrapApiCallAsync[T](Func`1 action, Boolean isInternal, String title) in /_/src/Playwright/Transport/Connection.cs:line 499
   at Microsoft.Playwright.Core.BrowserType.LaunchAsync(BrowserTypeLaunchOptions options) in /_/src/Playwright/Core/BrowserType.cs:line 56
   at Microsoft.Playwright.Xunit.BrowserService.CreateBrowser(IBrowserType browserType, Nullable`1 connectOptions) in /_/src/Playwright.Xunit/BrowserService.cs:line 66
   at Microsoft.Playwright.Xunit.BrowserService.<>c__DisplayClass5_0.<<Register>b__0>d.MoveNext() in /_/src/Playwright.Xunit/BrowserService.cs:line 47
--- End of stack trace from previous location ---
   at Microsoft.Playwright.Xunit.WorkerAwareTest.RegisterService[T](String name, Func`1 factory) in /_/src/Playwright.Xunit/WorkerAwareTest.cs:line 54
   at Microsoft.Playwright.Xunit.BrowserTest.InitializeAsync() in /_/src/Playwright.Xunit/BrowserTest.cs:line 45
   at Microsoft.Playwright.Xunit.ContextTest.InitializeAsync() in /_/src/Playwright.Xunit/ContextTest.cs:line 35
   at Microsoft.Playwright.Xunit.PageTest.InitializeAsync() in /_/src/Playwright.Xunit/PageTest.cs:line 35
   at OpenChat.PlaygroundApp.Tests.Components.Pages.Chat.ChatInputUITest.InitializeAsync() in /Users/gremh/src/open-chat-playground/test/OpenChat.PlaygroundApp.Tests/Components/Pages/Chat/ChatInputUITests.cs:line 10
  Failed OpenChat.PlaygroundApp.Tests.Components.Pages.Chat.ChatInputUITest.Given_UserMessage_When_EnterKey_Pressed_Then_It_Should_SendMessage(userMessage: "하늘은 왜 푸른 색인가요?", expectedMessageCount: 1) [1 ms]
  Error Message:
   Microsoft.Playwright.PlaywrightException : Executable doesn't exist at /Users/gremh/Library/Caches/ms-playwright/chromium_headless_shell-1181/chrome-mac/headless_shell
╔════════════════════════════════════════════════════════════╗
║ Looks like Playwright was just installed or updated.       ║
║ Please run the following command to download new browsers: ║
║                                                            ║
║     pwsh bin/Debug/netX/playwright.ps1 install             ║
║                                                            ║
║ <3 Playwright Team                                         ║
╚════════════════════════════════════════════════════════════╝
  Stack Trace:
     at Microsoft.Playwright.Transport.Connection.InnerSendMessageToServerAsync[T](ChannelOwner object, String method, Dictionary`2 dictionary, Boolean keepNulls) in /_/src/Playwright/Transport/Connection.cs:line 201
   at Microsoft.Playwright.Transport.Connection.WrapApiCallAsync[T](Func`1 action, Boolean isInternal, String title) in /_/src/Playwright/Transport/Connection.cs:line 499
   at Microsoft.Playwright.Core.BrowserType.LaunchAsync(BrowserTypeLaunchOptions options) in /_/src/Playwright/Core/BrowserType.cs:line 56
   at Microsoft.Playwright.Xunit.BrowserService.CreateBrowser(IBrowserType browserType, Nullable`1 connectOptions) in /_/src/Playwright.Xunit/BrowserService.cs:line 66
   at Microsoft.Playwright.Xunit.BrowserService.<>c__DisplayClass5_0.<<Register>b__0>d.MoveNext() in /_/src/Playwright.Xunit/BrowserService.cs:line 47
--- End of stack trace from previous location ---
   at Microsoft.Playwright.Xunit.WorkerAwareTest.RegisterService[T](String name, Func`1 factory) in /_/src/Playwright.Xunit/WorkerAwareTest.cs:line 54
   at Microsoft.Playwright.Xunit.BrowserTest.InitializeAsync() in /_/src/Playwright.Xunit/BrowserTest.cs:line 45
   at Microsoft.Playwright.Xunit.ContextTest.InitializeAsync() in /_/src/Playwright.Xunit/ContextTest.cs:line 35
   at Microsoft.Playwright.Xunit.PageTest.InitializeAsync() in /_/src/Playwright.Xunit/PageTest.cs:line 35
   at OpenChat.PlaygroundApp.Tests.Components.Pages.Chat.ChatInputUITest.InitializeAsync() in /Users/gremh/src/open-chat-playground/test/OpenChat.PlaygroundApp.Tests/Components/Pages/Chat/ChatInputUITests.cs:line 10
  Failed OpenChat.PlaygroundApp.Tests.Components.Pages.Chat.ChatInputUITest.Given_UserMessage_When_EnterKey_Pressed_Then_It_Should_SendMessage(userMessage: "Why is the sky blue?", expectedMessageCount: 1) [1 ms]
  Error Message:
   Microsoft.Playwright.PlaywrightException : Executable doesn't exist at /Users/gremh/Library/Caches/ms-playwright/chromium_headless_shell-1181/chrome-mac/headless_shell
╔════════════════════════════════════════════════════════════╗
║ Looks like Playwright was just installed or updated.       ║
║ Please run the following command to download new browsers: ║
║                                                            ║
║     pwsh bin/Debug/netX/playwright.ps1 install             ║
║                                                            ║
║ <3 Playwright Team                                         ║
╚════════════════════════════════════════════════════════════╝
  Stack Trace:
     at Microsoft.Playwright.Transport.Connection.InnerSendMessageToServerAsync[T](ChannelOwner object, String method, Dictionary`2 dictionary, Boolean keepNulls) in /_/src/Playwright/Transport/Connection.cs:line 201
   at Microsoft.Playwright.Transport.Connection.WrapApiCallAsync[T](Func`1 action, Boolean isInternal, String title) in /_/src/Playwright/Transport/Connection.cs:line 499
   at Microsoft.Playwright.Core.BrowserType.LaunchAsync(BrowserTypeLaunchOptions options) in /_/src/Playwright/Core/BrowserType.cs:line 56
   at Microsoft.Playwright.Xunit.BrowserService.CreateBrowser(IBrowserType browserType, Nullable`1 connectOptions) in /_/src/Playwright.Xunit/BrowserService.cs:line 66
   at Microsoft.Playwright.Xunit.BrowserService.<>c__DisplayClass5_0.<<Register>b__0>d.MoveNext() in /_/src/Playwright.Xunit/BrowserService.cs:line 47
--- End of stack trace from previous location ---
   at Microsoft.Playwright.Xunit.WorkerAwareTest.RegisterService[T](String name, Func`1 factory) in /_/src/Playwright.Xunit/WorkerAwareTest.cs:line 54
   at Microsoft.Playwright.Xunit.BrowserTest.InitializeAsync() in /_/src/Playwright.Xunit/BrowserTest.cs:line 45
   at Microsoft.Playwright.Xunit.ContextTest.InitializeAsync() in /_/src/Playwright.Xunit/ContextTest.cs:line 35
   at Microsoft.Playwright.Xunit.PageTest.InitializeAsync() in /_/src/Playwright.Xunit/PageTest.cs:line 35
   at OpenChat.PlaygroundApp.Tests.Components.Pages.Chat.ChatInputUITest.InitializeAsync() in /Users/gremh/src/open-chat-playground/test/OpenChat.PlaygroundApp.Tests/Components/Pages/Chat/ChatInputUITests.cs:line 10
  Failed OpenChat.PlaygroundApp.Tests.Components.Pages.Chat.ChatInputUITest.Given_Empty_UserMessage_When_EnterKey_Pressed_Then_It_Should_Not_SendMessage(userMessage: "", expectedMessageCount: 0) [1 ms]
  Error Message:
   Microsoft.Playwright.PlaywrightException : Executable doesn't exist at /Users/gremh/Library/Caches/ms-playwright/chromium_headless_shell-1181/chrome-mac/headless_shell
╔════════════════════════════════════════════════════════════╗
║ Looks like Playwright was just installed or updated.       ║
║ Please run the following command to download new browsers: ║
║                                                            ║
║     pwsh bin/Debug/netX/playwright.ps1 install             ║
║                                                            ║
║ <3 Playwright Team                                         ║
╚════════════════════════════════════════════════════════════╝
  Stack Trace:
     at Microsoft.Playwright.Transport.Connection.InnerSendMessageToServerAsync[T](ChannelOwner object, String method, Dictionary`2 dictionary, Boolean keepNulls) in /_/src/Playwright/Transport/Connection.cs:line 201
   at Microsoft.Playwright.Transport.Connection.WrapApiCallAsync[T](Func`1 action, Boolean isInternal, String title) in /_/src/Playwright/Transport/Connection.cs:line 499
   at Microsoft.Playwright.Core.BrowserType.LaunchAsync(BrowserTypeLaunchOptions options) in /_/src/Playwright/Core/BrowserType.cs:line 56
   at Microsoft.Playwright.Xunit.BrowserService.CreateBrowser(IBrowserType browserType, Nullable`1 connectOptions) in /_/src/Playwright.Xunit/BrowserService.cs:line 66
   at Microsoft.Playwright.Xunit.BrowserService.<>c__DisplayClass5_0.<<Register>b__0>d.MoveNext() in /_/src/Playwright.Xunit/BrowserService.cs:line 47
--- End of stack trace from previous location ---
   at Microsoft.Playwright.Xunit.WorkerAwareTest.RegisterService[T](String name, Func`1 factory) in /_/src/Playwright.Xunit/WorkerAwareTest.cs:line 54
   at Microsoft.Playwright.Xunit.BrowserTest.InitializeAsync() in /_/src/Playwright.Xunit/BrowserTest.cs:line 45
   at Microsoft.Playwright.Xunit.ContextTest.InitializeAsync() in /_/src/Playwright.Xunit/ContextTest.cs:line 35
   at Microsoft.Playwright.Xunit.PageTest.InitializeAsync() in /_/src/Playwright.Xunit/PageTest.cs:line 35
   at OpenChat.PlaygroundApp.Tests.Components.Pages.Chat.ChatInputUITest.InitializeAsync() in /Users/gremh/src/open-chat-playground/test/OpenChat.PlaygroundApp.Tests/Components/Pages/Chat/ChatInputUITests.cs:line 10
  Failed OpenChat.PlaygroundApp.Tests.Components.Pages.Chat.ChatInputUITest.Given_Empty_UserMessage_When_SendButton_Clicked_Then_It_Should_Not_SendMessage(userMessage: "", expectedMessageCount: 0) [1 ms]
  Error Message:
   Microsoft.Playwright.PlaywrightException : Executable doesn't exist at /Users/gremh/Library/Caches/ms-playwright/chromium_headless_shell-1181/chrome-mac/headless_shell
╔════════════════════════════════════════════════════════════╗
║ Looks like Playwright was just installed or updated.       ║
║ Please run the following command to download new browsers: ║
║                                                            ║
║     pwsh bin/Debug/netX/playwright.ps1 install             ║
║                                                            ║
║ <3 Playwright Team                                         ║
╚════════════════════════════════════════════════════════════╝
  Stack Trace:
     at Microsoft.Playwright.Transport.Connection.InnerSendMessageToServerAsync[T](ChannelOwner object, String method, Dictionary`2 dictionary, Boolean keepNulls) in /_/src/Playwright/Transport/Connection.cs:line 201
   at Microsoft.Playwright.Transport.Connection.WrapApiCallAsync[T](Func`1 action, Boolean isInternal, String title) in /_/src/Playwright/Transport/Connection.cs:line 499
   at Microsoft.Playwright.Core.BrowserType.LaunchAsync(BrowserTypeLaunchOptions options) in /_/src/Playwright/Core/BrowserType.cs:line 56
   at Microsoft.Playwright.Xunit.BrowserService.CreateBrowser(IBrowserType browserType, Nullable`1 connectOptions) in /_/src/Playwright.Xunit/BrowserService.cs:line 66
   at Microsoft.Playwright.Xunit.BrowserService.<>c__DisplayClass5_0.<<Register>b__0>d.MoveNext() in /_/src/Playwright.Xunit/BrowserService.cs:line 47
--- End of stack trace from previous location ---
   at Microsoft.Playwright.Xunit.WorkerAwareTest.RegisterService[T](String name, Func`1 factory) in /_/src/Playwright.Xunit/WorkerAwareTest.cs:line 54
   at Microsoft.Playwright.Xunit.BrowserTest.InitializeAsync() in /_/src/Playwright.Xunit/BrowserTest.cs:line 45
   at Microsoft.Playwright.Xunit.ContextTest.InitializeAsync() in /_/src/Playwright.Xunit/ContextTest.cs:line 35
   at Microsoft.Playwright.Xunit.PageTest.InitializeAsync() in /_/src/Playwright.Xunit/PageTest.cs:line 35
   at OpenChat.PlaygroundApp.Tests.Components.Pages.Chat.ChatInputUITest.InitializeAsync() in /Users/gremh/src/open-chat-playground/test/OpenChat.PlaygroundApp.Tests/Components/Pages/Chat/ChatInputUITests.cs:line 10
  Failed OpenChat.PlaygroundApp.Tests.Components.Pages.Chat.ChatInputUITest.Given_UserMessage_When_SendButton_Clicked_Then_It_Should_SendMessage(userMessage: "Why is the sky blue?", expectedMessageCount: 1) [1 ms]
  Error Message:
   Microsoft.Playwright.PlaywrightException : Executable doesn't exist at /Users/gremh/Library/Caches/ms-playwright/chromium_headless_shell-1181/chrome-mac/headless_shell
╔════════════════════════════════════════════════════════════╗
║ Looks like Playwright was just installed or updated.       ║
║ Please run the following command to download new browsers: ║
║                                                            ║
║     pwsh bin/Debug/netX/playwright.ps1 install             ║
║                                                            ║
║ <3 Playwright Team                                         ║
╚════════════════════════════════════════════════════════════╝
  Stack Trace:
     at Microsoft.Playwright.Transport.Connection.InnerSendMessageToServerAsync[T](ChannelOwner object, String method, Dictionary`2 dictionary, Boolean keepNulls) in /_/src/Playwright/Transport/Connection.cs:line 201
   at Microsoft.Playwright.Transport.Connection.WrapApiCallAsync[T](Func`1 action, Boolean isInternal, String title) in /_/src/Playwright/Transport/Connection.cs:line 499
   at Microsoft.Playwright.Core.BrowserType.LaunchAsync(BrowserTypeLaunchOptions options) in /_/src/Playwright/Core/BrowserType.cs:line 56
   at Microsoft.Playwright.Xunit.BrowserService.CreateBrowser(IBrowserType browserType, Nullable`1 connectOptions) in /_/src/Playwright.Xunit/BrowserService.cs:line 66
   at Microsoft.Playwright.Xunit.BrowserService.<>c__DisplayClass5_0.<<Register>b__0>d.MoveNext() in /_/src/Playwright.Xunit/BrowserService.cs:line 47
--- End of stack trace from previous location ---
   at Microsoft.Playwright.Xunit.WorkerAwareTest.RegisterService[T](String name, Func`1 factory) in /_/src/Playwright.Xunit/WorkerAwareTest.cs:line 54
   at Microsoft.Playwright.Xunit.BrowserTest.InitializeAsync() in /_/src/Playwright.Xunit/BrowserTest.cs:line 45
   at Microsoft.Playwright.Xunit.ContextTest.InitializeAsync() in /_/src/Playwright.Xunit/ContextTest.cs:line 35
   at Microsoft.Playwright.Xunit.PageTest.InitializeAsync() in /_/src/Playwright.Xunit/PageTest.cs:line 35
   at OpenChat.PlaygroundApp.Tests.Components.Pages.Chat.ChatInputUITest.InitializeAsync() in /Users/gremh/src/open-chat-playground/test/OpenChat.PlaygroundApp.Tests/Components/Pages/Chat/ChatInputUITests.cs:line 10
  Failed OpenChat.PlaygroundApp.Tests.Components.Pages.Chat.ChatInputUITest.Given_UserMessage_When_SendButton_Clicked_Then_It_Should_SendMessage(userMessage: "하늘은 왜 푸른 색인가요?", expectedMessageCount: 1) [1 ms]
  Error Message:
   Microsoft.Playwright.PlaywrightException : Executable doesn't exist at /Users/gremh/Library/Caches/ms-playwright/chromium_headless_shell-1181/chrome-mac/headless_shell
╔════════════════════════════════════════════════════════════╗
║ Looks like Playwright was just installed or updated.       ║
║ Please run the following command to download new browsers: ║
║                                                            ║
║     pwsh bin/Debug/netX/playwright.ps1 install             ║
║                                                            ║
║ <3 Playwright Team                                         ║
╚════════════════════════════════════════════════════════════╝
  Stack Trace:
     at Microsoft.Playwright.Transport.Connection.InnerSendMessageToServerAsync[T](ChannelOwner object, String method, Dictionary`2 dictionary, Boolean keepNulls) in /_/src/Playwright/Transport/Connection.cs:line 201
   at Microsoft.Playwright.Transport.Connection.WrapApiCallAsync[T](Func`1 action, Boolean isInternal, String title) in /_/src/Playwright/Transport/Connection.cs:line 499
   at Microsoft.Playwright.Core.BrowserType.LaunchAsync(BrowserTypeLaunchOptions options) in /_/src/Playwright/Core/BrowserType.cs:line 56
   at Microsoft.Playwright.Xunit.BrowserService.CreateBrowser(IBrowserType browserType, Nullable`1 connectOptions) in /_/src/Playwright.Xunit/BrowserService.cs:line 66
   at Microsoft.Playwright.Xunit.BrowserService.<>c__DisplayClass5_0.<<Register>b__0>d.MoveNext() in /_/src/Playwright.Xunit/BrowserService.cs:line 47
--- End of stack trace from previous location ---
   at Microsoft.Playwright.Xunit.WorkerAwareTest.RegisterService[T](String name, Func`1 factory) in /_/src/Playwright.Xunit/WorkerAwareTest.cs:line 54
   at Microsoft.Playwright.Xunit.BrowserTest.InitializeAsync() in /_/src/Playwright.Xunit/BrowserTest.cs:line 45
   at Microsoft.Playwright.Xunit.ContextTest.InitializeAsync() in /_/src/Playwright.Xunit/ContextTest.cs:line 35
   at Microsoft.Playwright.Xunit.PageTest.InitializeAsync() in /_/src/Playwright.Xunit/PageTest.cs:line 35
   at OpenChat.PlaygroundApp.Tests.Components.Pages.Chat.ChatInputUITest.InitializeAsync() in /Users/gremh/src/open-chat-playground/test/OpenChat.PlaygroundApp.Tests/Components/Pages/Chat/ChatInputUITests.cs:line 10
  Failed OpenChat.PlaygroundApp.Tests.Components.Pages.Chat.ChatInputUITest.Given_Empty_UserMessage_Then_It_Should_Not_Change_Color_Of_SendButton(userMessage: "", expectedButtonColor: "rgb(170, 170, 170)") [1 ms]
  Error Message:
   Microsoft.Playwright.PlaywrightException : Executable doesn't exist at /Users/gremh/Library/Caches/ms-playwright/chromium_headless_shell-1181/chrome-mac/headless_shell
╔════════════════════════════════════════════════════════════╗
║ Looks like Playwright was just installed or updated.       ║
║ Please run the following command to download new browsers: ║
║                                                            ║
║     pwsh bin/Debug/netX/playwright.ps1 install             ║
║                                                            ║
║ <3 Playwright Team                                         ║
╚════════════════════════════════════════════════════════════╝
  Stack Trace:
     at Microsoft.Playwright.Transport.Connection.InnerSendMessageToServerAsync[T](ChannelOwner object, String method, Dictionary`2 dictionary, Boolean keepNulls) in /_/src/Playwright/Transport/Connection.cs:line 201
   at Microsoft.Playwright.Transport.Connection.WrapApiCallAsync[T](Func`1 action, Boolean isInternal, String title) in /_/src/Playwright/Transport/Connection.cs:line 499
   at Microsoft.Playwright.Core.BrowserType.LaunchAsync(BrowserTypeLaunchOptions options) in /_/src/Playwright/Core/BrowserType.cs:line 56
   at Microsoft.Playwright.Xunit.BrowserService.CreateBrowser(IBrowserType browserType, Nullable`1 connectOptions) in /_/src/Playwright.Xunit/BrowserService.cs:line 66
   at Microsoft.Playwright.Xunit.BrowserService.<>c__DisplayClass5_0.<<Register>b__0>d.MoveNext() in /_/src/Playwright.Xunit/BrowserService.cs:line 47
--- End of stack trace from previous location ---
   at Microsoft.Playwright.Xunit.WorkerAwareTest.RegisterService[T](String name, Func`1 factory) in /_/src/Playwright.Xunit/WorkerAwareTest.cs:line 54
   at Microsoft.Playwright.Xunit.BrowserTest.InitializeAsync() in /_/src/Playwright.Xunit/BrowserTest.cs:line 45
   at Microsoft.Playwright.Xunit.ContextTest.InitializeAsync() in /_/src/Playwright.Xunit/ContextTest.cs:line 35
   at Microsoft.Playwright.Xunit.PageTest.InitializeAsync() in /_/src/Playwright.Xunit/PageTest.cs:line 35
   at OpenChat.PlaygroundApp.Tests.Components.Pages.Chat.ChatInputUITest.InitializeAsync() in /Users/gremh/src/open-chat-playground/test/OpenChat.PlaygroundApp.Tests/Components/Pages/Chat/ChatInputUITests.cs:line 10

Failed!  - Failed:    10, Passed:    75, Skipped:     0, Total:    85, Duration: 2 s - OpenChat.PlaygroundApp.Tests.dll (net9.0)

## What to Check
Verify that the following are valid
* UpstageSolarSettings class compiles without errors
* Class properly inherits from LanguageModelSettings base class
* All properties (BaseUrl, ApiKey, Model) are properly defined with correct types
* AppSettings partial class extension includes Upstage property
* XML documentation is complete and accurate
* Configuration binding works with appsettings.json structure

## Other Information
* This implementation follows the same pattern as GitHubModelsSettings for consistency
* The class is ready for integration with future Upstage Solar connector implementation
* Addresses Issue #233: Model Class Implementation: Upstage Solar