### PR TITLE
Add LG EXAONE Connector Support

### DIFF
--- a/src/OpenChat.PlaygroundApp/Abstractions/ArgumentOptions.cs
+++ b/src/OpenChat.PlaygroundApp/Abstractions/ArgumentOptions.cs
@@ -16,7 +16,7 @@ public abstract class ArgumentOptions
         // GitHub Models
         (ConnectorType.GitHubModels, "--endpoint", false),
         (ConnectorType.GitHubModels, "--token", false),
-        (ConnectorType.GitHubModels, "--model", false)
+        (ConnectorType.GitHubModels, "--model", false),
         // Google Vertex AI
         // Docker Model Runner
         // Foundry Local
@@ -24,6 +24,8 @@ public abstract class ArgumentOptions
         // Ollama
         // Anthropic
         // LG
+        (ConnectorType.LG, "--base-url", false),
+        (ConnectorType.LG, "--model", false)
         // Naver
         // OpenAI
         // Upstage
@@ -139,6 +141,12 @@ public abstract class ArgumentOptions
                 settings.GitHubModels.Endpoint = github.Endpoint ?? settings.GitHubModels.Endpoint;
                 settings.GitHubModels.Token = github.Token ?? settings.GitHubModels.Token;
                 settings.GitHubModels.Model = github.Model ?? settings.GitHubModels.Model;
+                break;
+
+            case LGArgumentOptions lg:
+                settings.LG ??= new LGSettings();
+                settings.LG.BaseUrl = lg.BaseUrl ?? settings.LG.BaseUrl;
+                settings.LG.Model = lg.Model ?? settings.LG.Model;
                 break;
 
             default:
@@ -311,10 +319,11 @@ public abstract class ArgumentOptions
     {
         var foregroundColor = Console.ForegroundColor;
         Console.ForegroundColor = ConsoleColor.DarkGreen;
-        Console.WriteLine("  ** LG: **");
+        Console.WriteLine("  ** LG (LG Models via OllamaSharp): **");
         Console.ForegroundColor = foregroundColor;
 
-        Console.WriteLine("  TBD");
+        Console.WriteLine("  --base-url           The base URL for Ollama API. Default to 'http://localhost:11434'");
+        Console.WriteLine("  --model              The LG model name. Default to 'lg-model:latest'");
         Console.WriteLine();
     }
 

--- a/src/OpenChat.PlaygroundApp/Abstractions/LanguageModelConnector.cs
+++ b/src/OpenChat.PlaygroundApp/Abstractions/LanguageModelConnector.cs
@@ -31,6 +31,7 @@ public abstract class LanguageModelConnector(LanguageModelSettings? settings)
         LanguageModelConnector connector = settings.ConnectorType switch
         {
             ConnectorType.GitHubModels => new GitHubModelsConnector(settings),
+            ConnectorType.LG => new LGConnector(settings),
             _ => throw new NotSupportedException($"Connector type '{settings.ConnectorType}' is not supported.")
         };
 

--- a/src/OpenChat.PlaygroundApp/Configurations/LGSettings.cs
+++ b/src/OpenChat.PlaygroundApp/Configurations/LGSettings.cs
@@ -1,0 +1,28 @@
+using OpenChat.PlaygroundApp.Abstractions;
+
+namespace OpenChat.PlaygroundApp.Configurations;
+
+/// <inheritdoc/>
+public partial class AppSettings
+{
+    /// <summary>
+    /// Gets or sets the <see cref="LGSettings"/> instance.
+    /// </summary>
+    public LGSettings? LG { get; set; }
+}
+
+/// <summary>
+/// This represents the app settings entity for LG models.
+/// </summary>
+public class LGSettings : LanguageModelSettings
+{
+    /// <summary>
+    /// Gets or sets the base URL of the Ollama API for LG models.
+    /// </summary>
+    public string? BaseUrl { get; set; }
+
+    /// <summary>
+    /// Gets or sets the LG model name.
+    /// </summary>
+    public string? Model { get; set; }
+}

--- a/src/OpenChat.PlaygroundApp/Connectors/LGConnector.cs
+++ b/src/OpenChat.PlaygroundApp/Connectors/LGConnector.cs
@@ -1,0 +1,30 @@
+using Microsoft.Extensions.AI;
+using OllamaSharp;
+using OpenChat.PlaygroundApp.Abstractions;
+using OpenChat.PlaygroundApp.Configurations;
+
+// Temporary workaround for OllamaSharp IChatClient integration
+
+namespace OpenChat.PlaygroundApp.Connectors;
+
+/// <summary>
+/// This represents the connector entity for LG models through OllamaSharp.
+/// </summary>
+public class LGConnector(AppSettings settings) : LanguageModelConnector(settings.LG)
+{
+    /// <inheritdoc/>
+    public override async Task<IChatClient> GetChatClientAsync()
+    {
+        var settings = this.Settings as LGSettings;
+
+        var baseUrl = settings?.BaseUrl ?? throw new InvalidOperationException("Missing configuration: LG:BaseUrl.");
+        var model = settings?.Model ?? throw new InvalidOperationException("Missing configuration: LG:Model.");
+
+        var uri = new Uri(baseUrl);
+        
+        // Use OllamaSharp official way: OllamaApiClient directly implements IChatClient
+        IChatClient chatClient = new OllamaApiClient(uri, model);
+        
+        return await Task.FromResult(chatClient).ConfigureAwait(false);
+    }
+}

--- a/src/OpenChat.PlaygroundApp/OpenChat.PlaygroundApp.csproj
+++ b/src/OpenChat.PlaygroundApp/OpenChat.PlaygroundApp.csproj
@@ -17,6 +17,8 @@
     <PackageReference Include="AWSSDK.Extensions.Bedrock.MEAI" Version="4.*-*" />
     <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="9.*-*" />
     <PackageReference Include="Microsoft.Extensions.AI" Version="9.*-*" />
+    <PackageReference Include="Microsoft.Extensions.AI.Abstractions" Version="9.*-*" />
+    <PackageReference Include="OllamaSharp" Version="5.*" />
     <PackageReference Include="System.Linq.Async" Version="6.*" />
   </ItemGroup>
 

--- a/src/OpenChat.PlaygroundApp/Options/LGArgumentOptions.cs
+++ b/src/OpenChat.PlaygroundApp/Options/LGArgumentOptions.cs
@@ -1,0 +1,55 @@
+using OpenChat.PlaygroundApp.Abstractions;
+using OpenChat.PlaygroundApp.Configurations;
+
+namespace OpenChat.PlaygroundApp.Options;
+
+/// <summary>
+/// This represents the argument options entity for LG models.
+/// </summary>
+public class LGArgumentOptions : ArgumentOptions
+{
+    /// <summary>
+    /// Gets or sets the base URL for Ollama API.
+    /// </summary>
+    public string? BaseUrl { get; set; }
+
+    /// <summary>
+    /// Gets or sets the LG model name.
+    /// </summary>
+    public string? Model { get; set; }
+
+    /// <inheritdoc/>
+    protected override void ParseOptions(IConfiguration config, string[] args)
+    {
+        var settings = new AppSettings();
+        config.Bind(settings);
+
+        var lg = settings.LG;
+
+        this.BaseUrl ??= lg?.BaseUrl;
+        this.Model ??= lg?.Model;
+
+        for (var i = 0; i < args.Length; i++)
+        {
+            switch (args[i])
+            {
+                case "--base-url":
+                    if (i + 1 < args.Length)
+                    {
+                        this.BaseUrl = args[++i];
+                    }
+                    break;
+
+                case "--model":
+                    if (i + 1 < args.Length)
+                    {
+                        this.Model = args[++i];
+                    }
+                    break;
+
+                default:
+                    break;
+            }
+        }
+    }
+}

--- a/src/OpenChat.PlaygroundApp/appsettings.json
+++ b/src/OpenChat.PlaygroundApp/appsettings.json
@@ -41,6 +41,11 @@
     "BaseUrl": "https://api.upstage.ai/v1",
     "ApiKey": "{{UPSTAGE_API_KEY}}",
     "Model": "solar-mini"
+  },
+
+  "LG": {
+    "BaseUrl": "http://localhost:11434",
+    "Model": "exaone3.5:7.8b"
   }
 }
 

--- a/src/OpenChat.PlaygroundApp/appsettings.json
+++ b/src/OpenChat.PlaygroundApp/appsettings.json
@@ -31,6 +31,11 @@
     "ApiKey": "{{ANTHROPIC_API_KEY}}",
     "Model": "claude-sonnet-4-0"
   },
+
+  "LG": {
+    "BaseUrl": "http://localhost:11434",
+    "Model": "exaone3.5:latest"
+  },
   
   "OpenAI": {
     "ApiKey": "{{OPENAI_API_KEY}}",
@@ -41,11 +46,5 @@
     "BaseUrl": "https://api.upstage.ai/v1",
     "ApiKey": "{{UPSTAGE_API_KEY}}",
     "Model": "solar-mini"
-  },
-
-  "LG": {
-    "BaseUrl": "http://localhost:11434",
-    "Model": "exaone3.5:7.8b"
   }
 }
-

--- a/test/OpenChat.PlaygroundApp.Tests/Connectors/LGConnectorTests.cs
+++ b/test/OpenChat.PlaygroundApp.Tests/Connectors/LGConnectorTests.cs
@@ -1,0 +1,78 @@
+using OpenChat.PlaygroundApp.Configurations;
+using OpenChat.PlaygroundApp.Connectors;
+using Xunit;
+
+namespace OpenChat.PlaygroundApp.Tests.Connectors;
+
+/// <summary>
+/// This represents the test entity for <see cref="LGConnector"/>.
+/// </summary>
+public class LGConnectorTests
+{
+    [Fact]
+    public void LGConnector_WithValidSettings_ShouldCreateInstance()
+    {
+        // Arrange
+        var settings = new AppSettings
+        {
+            ConnectorType = ConnectorType.LG,
+            LG = new LGSettings
+            {
+                BaseUrl = "http://localhost:11434",
+                Model = "lg-model:latest"
+            }
+        };
+
+        // Act
+        var connector = new LGConnector(settings);
+
+        // Assert
+        Assert.NotNull(connector);
+    }
+
+    [Fact]
+    public async Task LGConnector_WithMissingBaseUrl_ShouldThrowException()
+    {
+        // Arrange
+        var settings = new AppSettings
+        {
+            ConnectorType = ConnectorType.LG,
+            LG = new LGSettings
+            {
+                BaseUrl = null, // Missing BaseUrl
+                Model = "lg-model:latest"
+            }
+        };
+
+        var connector = new LGConnector(settings);
+
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => connector.GetChatClientAsync());
+        
+        Assert.Contains("Missing configuration: LG:BaseUrl", exception.Message);
+    }
+
+    [Fact]
+    public async Task LGConnector_WithMissingModel_ShouldThrowException()
+    {
+        // Arrange
+        var settings = new AppSettings
+        {
+            ConnectorType = ConnectorType.LG,
+            LG = new LGSettings
+            {
+                BaseUrl = "http://localhost:11434",
+                Model = null // Missing Model
+            }
+        };
+
+        var connector = new LGConnector(settings);
+
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => connector.GetChatClientAsync());
+        
+        Assert.Contains("Missing configuration: LG:Model", exception.Message);
+    }
+}

--- a/test/OpenChat.PlaygroundApp.Tests/Options/LGArgumentOptionsTests.cs
+++ b/test/OpenChat.PlaygroundApp.Tests/Options/LGArgumentOptionsTests.cs
@@ -1,0 +1,421 @@
+using Microsoft.Extensions.Configuration;
+
+using OpenChat.PlaygroundApp.Abstractions;
+using OpenChat.PlaygroundApp.Connectors;
+
+namespace OpenChat.PlaygroundApp.Tests.Options;
+
+public class LGArgumentOptionsTests
+{
+    private const string BaseUrl = "http://localhost:11434";
+    private const string Model = "exaone3.5:latest";
+
+    private static IConfiguration BuildConfigWithLG(
+        string? configBaseUrl = BaseUrl,
+        string? configModel = Model,
+        string? envBaseUrl = null,
+        string? envModel = null)
+    {
+        // Base configuration values (lowest priority)
+        var configDict = new Dictionary<string, string?>
+        {
+            ["ConnectorType"] = ConnectorType.LG.ToString()
+        };
+
+        if (string.IsNullOrWhiteSpace(configBaseUrl) == false)
+        {
+            configDict["LG:BaseUrl"] = configBaseUrl;
+        }
+        if (string.IsNullOrWhiteSpace(configModel) == false)
+        {
+            configDict["LG:Model"] = configModel;
+        }
+
+        if (string.IsNullOrWhiteSpace(envBaseUrl) && string.IsNullOrWhiteSpace(envModel))
+        {
+            return new ConfigurationBuilder()
+                       .AddInMemoryCollection(configDict!)
+                       .Build();
+        }
+
+        // Environment variables (medium priority)
+        var envDict = new Dictionary<string, string?>();
+        if (string.IsNullOrWhiteSpace(envBaseUrl) == false)
+        {
+            envDict["LG:BaseUrl"] = envBaseUrl;
+        }
+        if (string.IsNullOrWhiteSpace(envModel) == false)
+        {
+            envDict["LG:Model"] = envModel;
+        }
+
+        return new ConfigurationBuilder()
+                   .AddInMemoryCollection(configDict!)  // Base configuration (lowest priority)
+                   .AddInMemoryCollection(envDict!)     // Environment variables (medium priority)
+                   .Build();
+    }
+
+    [Trait("Category", "UnitTest")]
+    [Fact]
+    public void Given_Nothing_When_Parse_Invoked_Then_It_Should_Set_Config()
+    {
+        // Arrange
+        var config = BuildConfigWithLG();
+        var args = Array.Empty<string>();
+
+        // Act
+        var settings = ArgumentOptions.Parse(config, args);
+
+        // Assert
+        settings.LG.ShouldNotBeNull();
+        settings.LG.BaseUrl.ShouldBe(BaseUrl);
+        settings.LG.Model.ShouldBe(Model);
+    }
+
+    [Trait("Category", "UnitTest")]
+    [Theory]
+    [InlineData("http://test.example.com:8080")]
+    public void Given_CLI_BaseUrl_When_Parse_Invoked_Then_It_Should_Use_CLI_BaseUrl(string cliBaseUrl)
+    {
+        // Arrange
+        var config = BuildConfigWithLG();
+        var args = new[] { "--base-url", cliBaseUrl };
+
+        // Act
+        var settings = ArgumentOptions.Parse(config, args);
+
+        // Assert
+        settings.LG.ShouldNotBeNull();
+        settings.LG.BaseUrl.ShouldBe(cliBaseUrl);
+        settings.LG.Model.ShouldBe(Model);
+    }
+
+    [Trait("Category", "UnitTest")]
+    [Theory]
+    [InlineData("exaone3.5:latest")]
+    public void Given_CLI_Model_When_Parse_Invoked_Then_It_Should_Use_CLI_Model(string cliModel)
+    {
+        // Arrange
+        var config = BuildConfigWithLG();
+        var args = new[] { "--model", cliModel };
+
+        // Act
+        var settings = ArgumentOptions.Parse(config, args);
+
+        // Assert
+        settings.LG.ShouldNotBeNull();
+        settings.LG.BaseUrl.ShouldBe(BaseUrl);
+        settings.LG.Model.ShouldBe(cliModel);
+    }
+
+    [Trait("Category", "UnitTest")]
+    [Theory]
+    [InlineData("http://test.example.com:8080", "exaone3.5:latest")]
+    public void Given_All_CLI_Arguments_When_Parse_Invoked_Then_It_Should_Use_CLI(string cliBaseUrl, string cliModel)
+    {
+        // Arrange
+        var config = BuildConfigWithLG();
+        var args = new[] { "--base-url", cliBaseUrl, "--model", cliModel };
+
+        // Act
+        var settings = ArgumentOptions.Parse(config, args);
+
+        // Assert
+        settings.LG.ShouldNotBeNull();
+        settings.LG.BaseUrl.ShouldBe(cliBaseUrl);
+        settings.LG.Model.ShouldBe(cliModel);
+    }
+
+    [Trait("Category", "UnitTest")]
+    [Theory]
+    [InlineData("--base-url")]
+    [InlineData("--model")]
+    public void Given_CLI_ArgumentWithoutValue_When_Parse_Invoked_Then_It_Should_Use_Config(string argument)
+    {
+        // Arrange
+        var config = BuildConfigWithLG();
+        var args = new[] { argument };
+
+        // Act
+        var settings = ArgumentOptions.Parse(config, args);
+
+        // Assert
+        settings.LG.ShouldNotBeNull();
+        settings.LG.BaseUrl.ShouldBe(BaseUrl);
+        settings.LG.Model.ShouldBe(Model);
+    }
+
+    [Trait("Category", "UnitTest")]
+    [Theory]
+    [InlineData("--something", "else", "--another", "value")]
+    public void Given_Unrelated_CLI_Arguments_When_Parse_Invoked_Then_It_Should_Use_Config(params string[] args)
+    {
+        // Arrange
+        var config = BuildConfigWithLG();
+
+        // Act
+        var settings = ArgumentOptions.Parse(config, args);
+
+        // Assert
+        settings.LG.ShouldNotBeNull();
+        settings.LG.BaseUrl.ShouldBe(BaseUrl);
+        settings.LG.Model.ShouldBe(Model);
+    }
+
+    [Trait("Category", "UnitTest")]
+    [Theory]
+    [InlineData("http://localhost:11434", "exaone3.5:latest")]
+    public void Given_ConfigValues_And_No_CLI_When_Parse_Invoked_Then_It_Should_Use_Config(string configBaseUrl, string configModel)
+    {
+        // Arrange
+        var config = BuildConfigWithLG(configBaseUrl, configModel);
+        var args = Array.Empty<string>();
+
+        // Act
+        var settings = ArgumentOptions.Parse(config, args);
+
+        // Assert
+        settings.LG.ShouldNotBeNull();
+        settings.LG.BaseUrl.ShouldBe(configBaseUrl);
+        settings.LG.Model.ShouldBe(configModel);
+    }
+
+    [Trait("Category", "UnitTest")]
+    [Theory]
+    [InlineData("http://localhost:11434", "exaone3.5:latest",
+                "http://cli.example:8080", "exaone3.5:latest")]
+    public void Given_ConfigValues_And_CLI_When_Parse_Invoked_Then_It_Should_Use_CLI(
+        string configBaseUrl, string configModel,
+        string cliBaseUrl, string cliModel)
+    {
+        // Arrange
+        var config = BuildConfigWithLG(configBaseUrl, configModel);
+        var args = new[] { "--base-url", cliBaseUrl, "--model", cliModel };
+
+        // Act
+        var settings = ArgumentOptions.Parse(config, args);
+
+        // Assert
+        settings.LG.ShouldNotBeNull();
+        settings.LG.BaseUrl.ShouldBe(cliBaseUrl);
+        settings.LG.Model.ShouldBe(cliModel);
+    }
+
+    [Trait("Category", "UnitTest")]
+    [Theory]
+    [InlineData("--strange-model-name")]
+    public void Given_LG_With_ModelName_StartingWith_Dashes_When_Parse_Invoked_Then_It_Should_Treat_As_Value(string model)
+    {
+        // Arrange
+        var config = BuildConfigWithLG();
+        var args = new[] { "--model", model };
+
+        // Act
+        var settings = ArgumentOptions.Parse(config, args);
+
+        // Assert
+        settings.LG.ShouldNotBeNull();
+        settings.LG.Model.ShouldBe(model);
+    }
+
+    [Trait("Category", "UnitTest")]
+    [Theory]
+    [InlineData("http://env.example:9090", "exaone3.5:latest")]
+    public void Given_EnvironmentVariables_And_No_Config_When_Parse_Invoked_Then_It_Should_Use_EnvironmentVariables(
+        string envBaseUrl, string envModel)
+    {
+        // Arrange
+        var config = BuildConfigWithLG(
+            configBaseUrl: null, configModel: null,
+            envBaseUrl: envBaseUrl, envModel: envModel);
+        var args = Array.Empty<string>();
+
+        // Act
+        var settings = ArgumentOptions.Parse(config, args);
+
+        // Assert
+        settings.LG.ShouldNotBeNull();
+        settings.LG.BaseUrl.ShouldBe(envBaseUrl);
+        settings.LG.Model.ShouldBe(envModel);
+    }
+
+    [Trait("Category", "UnitTest")]
+    [Theory]
+    [InlineData("http://config.example:7070", "exaone3.5:latest",
+                "http://env.example:8080", "exaone3.5:latest")]
+    public void Given_ConfigValues_And_EnvironmentVariables_When_Parse_Invoked_Then_It_Should_Use_EnvironmentVariables(
+        string configBaseUrl, string configModel,
+        string envBaseUrl, string envModel)
+    {
+        // Arrange
+        var config = BuildConfigWithLG(
+            configBaseUrl, configModel,
+            envBaseUrl, envModel);
+        var args = Array.Empty<string>();
+
+        // Act
+        var settings = ArgumentOptions.Parse(config, args);
+
+        // Assert
+        settings.LG.ShouldNotBeNull();
+        settings.LG.BaseUrl.ShouldBe(envBaseUrl);
+        settings.LG.Model.ShouldBe(envModel);
+    }
+
+    [Trait("Category", "UnitTest")]
+    [Theory]
+    [InlineData("http://config.example:7070", "exaone3.5:latest",
+                "http://env.example:8080", "exaone3.5:latest",
+                "http://cli.example:9090", "exaone3.5:latest")]
+    public void Given_ConfigValues_And_EnvironmentVariables_And_CLI_When_Parse_Invoked_Then_It_Should_Use_CLI(
+        string configBaseUrl, string configModel,
+        string envBaseUrl, string envModel,
+        string cliBaseUrl, string cliModel)
+    {
+        // Arrange
+        var config = BuildConfigWithLG(
+            configBaseUrl, configModel,
+            envBaseUrl, envModel);
+        var args = new[] { "--base-url", cliBaseUrl, "--model", cliModel };
+
+        // Act
+        var settings = ArgumentOptions.Parse(config, args);
+
+        // Assert
+        settings.LG.ShouldNotBeNull();
+        settings.LG.BaseUrl.ShouldBe(cliBaseUrl);
+        settings.LG.Model.ShouldBe(cliModel);
+    }
+
+    [Trait("Category", "UnitTest")]
+    [Theory]
+    [InlineData("http://config.example:7070", "exaone3.5:latest",
+                "http://env.example:8080", null)]
+    public void Given_Partial_EnvironmentVariables_When_Parse_Invoked_Then_It_Should_Mix_Config_And_Environment(
+        string configBaseUrl, string configModel,
+        string envBaseUrl, string? envModel)
+    {
+        // Arrange
+        var config = BuildConfigWithLG(
+            configBaseUrl, configModel,
+            envBaseUrl, envModel);
+        var args = Array.Empty<string>();
+
+        // Act
+        var settings = ArgumentOptions.Parse(config, args);
+
+        // Assert
+        settings.LG.ShouldNotBeNull();
+        settings.LG.BaseUrl.ShouldBe(envBaseUrl); // From environment
+        settings.LG.Model.ShouldBe(configModel);  // From config (no env override)
+    }
+
+    [Trait("Category", "UnitTest")]
+    [Theory]
+    [InlineData("http://config.example:7070", "exaone3.5:latest",
+                null, "exaone3.5:latest",
+                "http://cli.example:9090")]
+    public void Given_Mixed_Priority_Sources_When_Parse_Invoked_Then_It_Should_Respect_Priority_Order(
+        string configBaseUrl, string configModel,
+        string? envBaseUrl, string envModel,
+        string cliBaseUrl)
+    {
+        // Arrange
+        var config = BuildConfigWithLG(
+            configBaseUrl, configModel,
+            envBaseUrl, envModel);
+        var args = new[] { "--base-url", cliBaseUrl };
+
+        // Act
+        var settings = ArgumentOptions.Parse(config, args);
+
+        // Assert
+        settings.LG.ShouldNotBeNull();
+        settings.LG.BaseUrl.ShouldBe(cliBaseUrl);    // CLI wins (highest priority)
+        settings.LG.Model.ShouldBe(envModel);        // Env wins over config (medium priority)
+    }
+
+    [Trait("Category", "UnitTest")]
+    [Theory]
+    [InlineData("http://localhost:11434", "exaone3.5:latest")]
+    public void Given_LG_With_KnownArguments_When_Parse_Invoked_Then_Help_ShouldBe_False(string cliBaseUrl, string cliModel)
+    {
+        // Arrange
+        var config = BuildConfigWithLG(BaseUrl, Model);
+        var args = new[] { "--base-url", cliBaseUrl, "--model", cliModel };
+
+        // Act
+        var settings = ArgumentOptions.Parse(config, args);
+
+        // Assert
+        settings.Help.ShouldBeFalse();
+    }
+
+    [Trait("Category", "UnitTest")]
+    [Theory]
+    [InlineData("--base-url")]
+    [InlineData("--model")]
+    public void Given_LG_With_KnownArgument_WithoutValue_When_Parse_Invoked_Then_Help_ShouldBe_False(string argument)
+    {
+        // Arrange
+        var config = BuildConfigWithLG();
+        var args = new[] { argument };
+
+        // Act
+        var settings = ArgumentOptions.Parse(config, args);
+
+        // Assert
+        settings.Help.ShouldBeFalse();
+    }
+
+    [Trait("Category", "UnitTest")]
+    [Theory]
+    [InlineData("http://localhost:11434", "--unknown-flag")]
+    public void Given_LG_With_Known_And_Unknown_Argument_When_Parse_Invoked_Then_Help_ShouldBe_True(string cliBaseUrl, string argument)
+    {
+        // Arrange
+        var config = BuildConfigWithLG();
+        var args = new[] { "--base-url", cliBaseUrl, argument };
+
+        // Act
+        var settings = ArgumentOptions.Parse(config, args);
+
+        // Assert
+        settings.Help.ShouldBeTrue();
+    }
+
+    [Trait("Category", "UnitTest")]
+    [Theory]
+    [InlineData("http://env.example:8080", "exaone3.5:latest")]
+    public void Given_EnvironmentVariables_Only_When_Parse_Invoked_Then_Help_Should_Be_False(
+        string envBaseUrl, string envModel)
+    {
+        // Arrange
+        var config = BuildConfigWithLG(
+            configBaseUrl: null, configModel: null,
+            envBaseUrl: envBaseUrl, envModel: envModel);
+        var args = Array.Empty<string>();
+
+        // Act
+        var settings = ArgumentOptions.Parse(config, args);
+
+        // Assert
+        settings.Help.ShouldBeFalse();
+    }
+
+    [Trait("Category", "UnitTest")]
+    [Theory]
+    [InlineData("http://cli.example:9090", "exaone3.5:latest")]
+    public void Given_CLI_Only_When_Parse_Invoked_Then_Help_Should_Be_False(string cliBaseUrl, string cliModel)
+    {
+        // Arrange
+        var config = BuildConfigWithLG();
+        var args = new[] { "--base-url", cliBaseUrl, "--model", cliModel };
+
+        // Act
+        var settings = ArgumentOptions.Parse(config, args);
+
+        // Assert
+        settings.Help.ShouldBeFalse();
+    }
+}


### PR DESCRIPTION
# Add LG EXAONE Connector Support

## Purpose
This pull request adds complete LG EXAONE connector support to the OpenChat Playground application. This implementation includes configuration management, command-line argument parsing, connector implementation, and comprehensive testing for LG EXAONE models through OllamaSharp integration.

**Closes #165, #246, #247, #248, #249, #250, #251, #252, #253, #344, #345, #346**

## Does this introduce a breaking change?
- [ ] Yes
- [x] No

## Pull Request Type
What kind of change does this Pull Request introduce?

- [ ] Bugfix
- [x] New feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## README updated?
The top-level readme for this repo contains a link to each sample in the repo. If you're adding a new sample did you update the readme?

- [ ] Yes
- [x] No
- [ ] N/A

## How to Test

### Get the code
```bash
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
```

### Test the code
```bash
dotnet build
dotnet test
dotnet run --project src/OpenChat.PlaygroundApp --connector-type LG --base-url http://localhost:11434 --model exaone3.5:latest
```

## What to Check
Verify that the following are valid:

### Configuration Support
- [ ] LG section is properly configured in `appsettings.json`
- [ ] `LGSettings` class correctly inherits from `LanguageModelSettings`
- [ ] Configuration binding works correctly with `BaseUrl` and `Model` properties

### Command-Line Arguments
- [ ] `--connector-type LG` option works
- [ ] `--base-url` argument sets the Ollama API endpoint
- [ ] `--model` argument sets the EXAONE model name
- [ ] CLI arguments override configuration file values
- [ ] Environment variables override configuration file values
- [ ] CLI arguments override environment variables (highest priority)

### Connector Implementation
- [ ] `LGConnector` properly inherits from `LanguageModelConnector`
- [ ] Connector successfully creates `OllamaApiClient` instances
- [ ] Error handling works for missing BaseUrl configuration
- [ ] Error handling works for missing Model configuration
- [ ] Integration with `ConnectorType.LG` enum value

### Testing Coverage
- [ ] `LGConnectorTests` - 3 test cases covering connector functionality
- [ ] `LGArgumentOptionsTests` - 21 test cases covering argument parsing
- [ ] All tests pass: `dotnet test --filter "FullyQualifiedName~LG"`
- [ ] Configuration priority testing (CLI > Environment > Config)
- [ ] Partial configuration scenarios
- [ ] Help display functionality

### Integration
- [ ] `ArgumentOptions` properly handles `LGArgumentOptions` case
- [ ] `LanguageModelConnector.CreateChatClientAsync` supports `ConnectorType.LG`
- [ ] Help display includes LG connector information
- [ ] No conflicts with existing connectors (GitHubModels, HuggingFace, etc.)

## Other Information

### Implementation Details

#### New Files Added:
- `src/OpenChat.PlaygroundApp/Configurations/LGSettings.cs`
- `src/OpenChat.PlaygroundApp/Connectors/LGConnector.cs`
- `src/OpenChat.PlaygroundApp/Options/LGArgumentOptions.cs`
- `test/OpenChat.PlaygroundApp.Tests/Connectors/LGConnectorTests.cs`
- `test/OpenChat.PlaygroundApp.Tests/Options/LGArgumentOptionsTests.cs`

#### Modified Files:
- `src/OpenChat.PlaygroundApp/Connectors/ConnectorType.cs` (added LG enum)
- `src/OpenChat.PlaygroundApp/Abstractions/ArgumentOptions.cs` (added LG support)
- `src/OpenChat.PlaygroundApp/Abstractions/LanguageModelConnector.cs` (added LG case)
- `src/OpenChat.PlaygroundApp/appsettings.json` (added LG configuration)

### Dependencies
- Uses existing `OllamaSharp` package for EXAONE model integration
- No additional NuGet packages required
- Compatible with .NET 9.0

### Usage Examples

#### Configuration File (`appsettings.json`)
```json
{
  "ConnectorType": "LG",
  "LG": {
    "BaseUrl": "http://localhost:11434",
    "Model": "exaone3.5:latest"
  }
}
```

#### Command Line Usage
```bash
# Using default configuration
dotnet run --project src/OpenChat.PlaygroundApp --connector-type LG

# Override model via CLI
dotnet run --project src/OpenChat.PlaygroundApp --connector-type LG --model exaone3.5:7.8b

# Override both base URL and model
dotnet run --project src/OpenChat.PlaygroundApp --connector-type LG --base-url http://localhost:11434 --model exaone3.5:32b
```

#### Environment Variables
```bash
export LG__BaseUrl="http://localhost:11434"
export LG__Model="exaone3.5:latest"
dotnet run --project src/OpenChat.PlaygroundApp --connector-type LG
```

### Testing Results
```bash
# Run all LG-related tests
dotnet test --filter "FullyQualifiedName~LG"

# Expected output:
# Test summary: total: 24, failed: 0, succeeded: 24, skipped: 0
```

### Available EXAONE Models
- `exaone3.5:latest` (default)
- `exaone3.5:2.4b` (2.4B parameters)
- `exaone3.5:7.8b` (7.8B parameters)
- `exaone3.5:32b` (32B parameters)