### PR TITLE
feat: (test code)enhance Hugging Face argument options to support environment variables and CLI overrides

### DIFF
--- a/test/OpenChat.PlaygroundApp.Tests/Options/HuggingFaceArgumentOptionsTests.cs
+++ b/test/OpenChat.PlaygroundApp.Tests/Options/HuggingFaceArgumentOptionsTests.cs
@@ -321,7 +321,7 @@ public class HuggingFaceArgumentOptionsTests
                 "https://cli.huggingface.co/api", null)]
     public void Given_Mixed_Priority_Sources_When_Parse_Invoked_Then_It_Should_Respect_Priority_Order(
         string configBaseUrl, string configModel,
-        string? envBaseUrl, string? envModel,
+        string? envBaseUrl, string envModel,
         string cliBaseUrl, string? cliModel)
     {
         // Arrange

--- a/test/OpenChat.PlaygroundApp.Tests/Options/HuggingFaceArgumentOptionsTests.cs
+++ b/test/OpenChat.PlaygroundApp.Tests/Options/HuggingFaceArgumentOptionsTests.cs
@@ -11,8 +11,10 @@ public class HuggingFaceArgumentOptionsTests
     private const string Model = "hf-model-name";
 
     private static IConfiguration BuildConfigWithHuggingFace(
-        string? baseUrl = BaseUrl,
-        string? model = Model
+        string? configBaseUrl = BaseUrl,
+        string? configModel = Model,
+        string? envBaseUrl = null,
+        string? envModel = null
     )
     {
         // Base configuration values (lowest priority)
@@ -21,18 +23,37 @@ public class HuggingFaceArgumentOptionsTests
             ["ConnectorType"] = ConnectorType.HuggingFace.ToString(),
         };
 
-        if (string.IsNullOrWhiteSpace(baseUrl) == false)
+        if (string.IsNullOrWhiteSpace(configBaseUrl) == false)
         {
-            configDict["HuggingFace:BaseUrl"] = baseUrl;
+            configDict["HuggingFace:BaseUrl"] = configBaseUrl;
         }
-        if (string.IsNullOrWhiteSpace(model) == false)
+        if (string.IsNullOrWhiteSpace(configModel) == false)
         {
-            configDict["HuggingFace:Model"] = model;
+            configDict["HuggingFace:Model"] = configModel;
+        }
+
+        if (string.IsNullOrWhiteSpace(envBaseUrl) && string.IsNullOrWhiteSpace(envModel))
+        {
+            return new ConfigurationBuilder()
+                       .AddInMemoryCollection(configDict!)
+                       .Build();
+        }
+
+        // Environment variables (medium priority)
+        var envDict = new Dictionary<string, string?>();
+        if (string.IsNullOrWhiteSpace(envBaseUrl) == false)
+        {
+            envDict["HuggingFace:BaseUrl"] = envBaseUrl;
+        }
+        if (string.IsNullOrWhiteSpace(envModel) == false)
+        {
+            envDict["HuggingFace:Model"] = envModel;
         }
 
         return new ConfigurationBuilder()
-                               .AddInMemoryCollection(configDict!)
-                               .Build();
+           .AddInMemoryCollection(configDict!)  // Base configuration (lowest priority)
+           .AddInMemoryCollection(envDict!)     // Environment variables (medium priority)
+           .Build();
     }
 
     [Trait("Category", "UnitTest")]
@@ -201,6 +222,125 @@ public class HuggingFaceArgumentOptionsTests
 
     [Trait("Category", "UnitTest")]
     [Theory]
+    [InlineData("https://env.huggingface.co/api", "env-model")]
+    public void Given_EnvironmentVariables_And_No_Config_When_Parse_Invoked_Then_It_Should_Use_EnvironmentVariables(
+        string envBaseUrl, string envModel)
+    {
+        // Arrange
+        var config = BuildConfigWithHuggingFace(
+            configBaseUrl: null, configModel: null,
+            envBaseUrl: envBaseUrl, envModel: envModel
+        );
+        var args = Array.Empty<string>();
+
+        // Act
+        var settings = ArgumentOptions.Parse(config, args);
+
+        // Assert
+        settings.HuggingFace.ShouldNotBeNull();
+        settings.HuggingFace.BaseUrl.ShouldBe(envBaseUrl);
+        settings.HuggingFace.Model.ShouldBe(envModel);
+    }
+
+    [Trait("Category", "UnitTest")]
+    [Theory]
+    [InlineData("https://config.huggingface.co/api", "config-model",
+                "https://env.huggingface.co/api", "env-model")]
+    public void Given_ConfigValues_And_EnvironmentVariables_When_Parse_Invoked_Then_It_Should_Use_EnvironmentVariables(
+        string configBaseUrl, string configModel,
+        string envBaseUrl, string envModel)
+    {
+        // Arrange
+        var config = BuildConfigWithHuggingFace(
+            configBaseUrl, configModel,
+            envBaseUrl, envModel);
+        var args = Array.Empty<string>();
+
+        // Act
+        var settings = ArgumentOptions.Parse(config, args);
+
+        // Assert
+        settings.HuggingFace.ShouldNotBeNull();
+        settings.HuggingFace.BaseUrl.ShouldBe(envBaseUrl);
+        settings.HuggingFace.Model.ShouldBe(envModel);
+    }
+
+    [Trait("Category", "UnitTest")]
+    [Theory]
+    [InlineData("https://config.huggingface.co/api", "config-model",
+                "https://env.huggingface.co/api", "env-model",
+                "https://cli.huggingface.co/api", "cli-model")]
+    public void Given_ConfigValues_And_EnvironmentVariables_And_CLI_When_Parse_Invoked_Then_It_Should_Use_CLI(
+        string configBaseUrl, string configModel,
+        string envBaseUrl, string envModel,
+        string cliBaseUrl, string cliModel)
+    {
+        // Arrange
+        var config = BuildConfigWithHuggingFace(
+            configBaseUrl, configModel,
+            envBaseUrl, envModel);
+        var args = new[] { "--base-url", cliBaseUrl, "--model", cliModel };
+
+        // Act
+        var settings = ArgumentOptions.Parse(config, args);
+
+        // Assert
+        settings.HuggingFace.ShouldNotBeNull();
+        settings.HuggingFace.BaseUrl.ShouldBe(cliBaseUrl);
+        settings.HuggingFace.Model.ShouldBe(cliModel);
+    }
+
+    [Trait("Category", "UnitTest")]
+    [Theory]
+    [InlineData("https://config.huggingface.co/api", "config-model",
+                "https://env.huggingface.co/api", null)]
+    public void Given_Partial_EnvironmentVariables_When_Parse_Invoked_Then_It_Should_Mix_Config_And_Environment(
+        string configBaseUrl, string configModel,
+        string envBaseUrl, string? envModel)
+    {
+        // Arrange
+        var config = BuildConfigWithHuggingFace(
+            configBaseUrl, configModel,
+            envBaseUrl, envModel);
+        var args = Array.Empty<string>();
+
+        // Act
+        var settings = ArgumentOptions.Parse(config, args);
+
+        // Assert
+        settings.HuggingFace.ShouldNotBeNull();
+        settings.HuggingFace.BaseUrl.ShouldBe(envBaseUrl);  // From environment
+        settings.HuggingFace.Model.ShouldBe(configModel);   // From config (no env override)
+    }
+
+
+    [Trait("Category", "UnitTest")]
+    [Theory]
+    [InlineData("https://config.huggingface.co/api", "config-model",
+                null, "env-model",
+                "https://cli.huggingface.co/api", null)]
+    public void Given_Mixed_Priority_Sources_When_Parse_Invoked_Then_It_Should_Respect_Priority_Order(
+        string configBaseUrl, string configModel,
+        string? envBaseUrl, string? envModel,
+        string cliBaseUrl, string? cliModel)
+    {
+        // Arrange
+        var config = BuildConfigWithHuggingFace(
+            configBaseUrl, configModel,
+            envBaseUrl, envModel);
+        var args = new[] { "--base-url", cliBaseUrl, "--model", cliModel };
+
+        // Act
+        var settings = ArgumentOptions.Parse(config, args!);
+
+        // Assert
+        settings.HuggingFace.ShouldNotBeNull();
+        settings.HuggingFace.BaseUrl.ShouldBe(cliBaseUrl);  // CLI wins (highest priority)
+        settings.HuggingFace.Model.ShouldBe(envModel);      // Env wins over config (medium priority)
+    }
+
+    [Trait("Category", "UnitTest")]
+    [Theory]
     [InlineData("https://cli.huggingface.co/api", "cli-model")]
     public void Given_HuggingFace_With_KnownArguments_When_Parse_Invoked_Then_Help_Should_Be_False(string cliBaseUrl, string cliModel)
     {
@@ -246,6 +386,26 @@ public class HuggingFaceArgumentOptionsTests
 
         // Assert
         settings.Help.ShouldBeTrue();
+    }
+
+
+    [Trait("Category", "UnitTest")]
+    [Theory]
+    [InlineData("https://env.huggingface.co/api", "env-model")]
+    public void Given_EnvironmentVariables_Only_When_Parse_Invoked_Then_Help_Should_Be_False(
+        string envBaseUrl, string envModel)
+    {
+        // Arrange
+        var config = BuildConfigWithHuggingFace(
+            configBaseUrl: null, configModel: null,
+            envBaseUrl: envBaseUrl, envModel: envModel);
+        var args = Array.Empty<string>();
+
+        // Act
+        var settings = ArgumentOptions.Parse(config, args);
+
+        // Assert
+        settings.Help.ShouldBeFalse();
     }
 
 


### PR DESCRIPTION
- close #286 

## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
Ensure HuggingFace configuration values are loaded from environment variables and that command-line arguments take precedence when provided. Add or adjust unit tests to verify env loading and CLI override behavior, reducing related test flakiness.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] New feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[x] Other... Please describe: (test)enhance Hugging Face argument options test
```

## README updated?

The top-level readme for this repo contains a link to each sample in the repo. If you're adding a new sample did you update the readme?
<!-- Mark one with an "x". -->
```
[ ] Yes
[ ] No
[x] N/A
```

## How to Test
* run test
<!-- Add steps to run the tests suite and/or manually test -->
```
dotnet test --filter Category=UnitTest
```

## What to Check
Verify that the following are valid
- Environment variables for HuggingFace options are loaded correctly
- Command-line arguments override environment variable values when both are provided.
- Default values are used when neither env vars nor CLI args are supplied.
- Unit tests (e.g., HuggingFaceArgumentOptionsTests) cover env loading and CLI override and all pass.
- CI pipeline runs successfully with these changes (no new test flakes).
