### PR TITLE
feat: Connector Implementation & Inheritance: OpenAI GPT #220

### DIFF
--- a/src/OpenChat.PlaygroundApp/Connectors/OpenAIConnector.cs
+++ b/src/OpenChat.PlaygroundApp/Connectors/OpenAIConnector.cs
@@ -1,0 +1,30 @@
+using System.ClientModel;
+
+using Microsoft.Extensions.AI;
+
+using OpenAI;
+
+using OpenChat.PlaygroundApp.Abstractions;
+using OpenChat.PlaygroundApp.Configurations;
+
+namespace OpenChat.PlaygroundApp.Connectors;
+
+/// <summary>
+/// This represents the connector entity for OpenAI.
+/// </summary>
+public class OpenAIConnector(AppSettings settings) : LanguageModelConnector(settings.OpenAI)
+{
+    /// <inheritdoc/>
+    public override async Task<IChatClient> GetChatClientAsync()
+    {
+        var settings = this.Settings as OpenAISettings;
+
+        var credential = new ApiKeyCredential(settings?.ApiKey ?? throw new InvalidOperationException("Missing configuration: OpenAI:ApiKey."));
+        
+        var client = new OpenAIClient(credential);
+        var chatClient = client.GetChatClient(settings.Model)
+                               .AsIChatClient();
+
+        return await Task.FromResult(chatClient).ConfigureAwait(false);
+    }
+}


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
 - Add AnthropicClaudeConnector and OpenAIConnector implementations
  - Inherit from LanguageModelConnector and inject AppSettings
  - Override GetChatClient method for each connector

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] New feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe: Add Connector for OpenAI GPT
```

## README updated?

The top-level readme for this repo contains a link to each sample in the repo. If you're adding a new sample did you update the readme?
<!-- Mark one with an "x". -->
```
[ ] Yes
[ ] No
[x] N/A
```

## How to Test
*  Get the code

```
git clone https://github.com/ummjevel/open-chat-playground.git
cd open-chat-playground
git checkout feature/261-connectorimpl-canthropic
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
  dotnet build
  dotnet test
```

## What to Check
  Verify that the following are valid
  - AnthropicClaudeConnector inherits from LanguageModelConnector
  - OpenAIConnector inherits from LanguageModelConnector
  - Both connectors properly inject AppSettings
  - GetChatClient methods are properly implemented
  - Configuration settings are validated (ApiKey, Model)

## Other Information
  - OpenAIConnector uses ApiKey and Model configurations (no custom endpoint needed)
  - Both follow the same pattern as existing GitHubModelsConnector
<!-- Add any other helpful information that may be needed here. -->