### PR TITLE
refactor: fix Mscc.GenerativeAI.Microsoft version

### DIFF
--- a/src/OpenChat.PlaygroundApp/OpenChat.PlaygroundApp.csproj
+++ b/src/OpenChat.PlaygroundApp/OpenChat.PlaygroundApp.csproj
@@ -19,8 +19,8 @@
     <PackageReference Include="Azure.AI.OpenAI" Version="2.*-*" />
     <PackageReference Include="Microsoft.AI.Foundry.Local" Version="0.*" />
     <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="9.*-*" />
-    <PackageReference Include="Mscc.GenerativeAI.Microsoft" Version="2.*-*" />
     <PackageReference Include="Microsoft.Extensions.AI" Version="9.*-*" />
+    <PackageReference Include="Mscc.GenerativeAI.Microsoft" Version="2.*" />
     <PackageReference Include="OllamaSharp" Version="5.*" />
     <PackageReference Include="System.Linq.Async" Version="6.*" />
   </ItemGroup>


### PR DESCRIPTION
Related to: #327

## Purpose
* `Mscc.GenerativeAI.Microsoft` does not support preview version
* Need to fix the version of `Mscc.GenerativeAI.Microsoft` in  `OpenChat.PlaygroundApp.csproj`

## Does this introduce a breaking change?
- [ ] Yes
- [x] No

## Pull Request Type
What kind of change does this Pull Request introduce?

- [ ] Bugfix
- [ ] New feature
- [x] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## README updated?

The top-level readme for this repo contains a link to each sample in the repo. If you're adding a new sample did you update the readme?

- [ ] Yes
- [ ] No
- [x] N/A

## What to Check
Verify that the following are valid
* Check that the version of `Mscc.GenerativeAI.Microsoft` is set to `2.*` in the `OpenChat.PlaygroundApp.csproj`
