### PR TITLE
feat: Command-Line Argument Options Modelling: Foundry Local  #332

### DIFF
--- a/src/OpenChat.PlaygroundApp/Abstractions/ArgumentOptions.cs
+++ b/src/OpenChat.PlaygroundApp/Abstractions/ArgumentOptions.cs
@@ -20,6 +20,7 @@ public abstract class ArgumentOptions
         // Google Vertex AI
         // Docker Model Runner
         // Foundry Local
+        (ConnectorType.FoundryLocal, "--alias", false),
         // Hugging Face
         (ConnectorType.HuggingFace, "--base-url", false),
         (ConnectorType.HuggingFace, "--model", false)
@@ -141,6 +142,11 @@ public abstract class ArgumentOptions
                 settings.GitHubModels.Endpoint = github.Endpoint ?? settings.GitHubModels.Endpoint;
                 settings.GitHubModels.Token = github.Token ?? settings.GitHubModels.Token;
                 settings.GitHubModels.Model = github.Model ?? settings.GitHubModels.Model;
+                break;
+
+            case FoundryLocalArgumentOptions foundryLocal:
+                settings.FoundryLocal ??= new FoundryLocalSettings();
+                settings.FoundryLocal.Alias = foundryLocal.Alias ?? settings.FoundryLocal.Alias;
                 break;
 
             case HuggingFaceArgumentOptions huggingFace:

--- a/src/OpenChat.PlaygroundApp/Options/FoundryLocalArgumentOptions.cs
+++ b/src/OpenChat.PlaygroundApp/Options/FoundryLocalArgumentOptions.cs
@@ -1,4 +1,5 @@
 using OpenChat.PlaygroundApp.Abstractions;
+using OpenChat.PlaygroundApp.Configurations;
 
 namespace OpenChat.PlaygroundApp.Options;
 
@@ -7,4 +8,35 @@ namespace OpenChat.PlaygroundApp.Options;
 /// </summary>
 public class FoundryLocalArgumentOptions : ArgumentOptions
 {
+    /// <summary>
+    /// Gets or sets the alias of Foundry Local.
+    /// </summary>
+    public string? Alias { get; set; }
+
+    /// <inheritdoc/>
+    protected override void ParseOptions(IConfiguration config, string[] args)
+    {
+        var settings = new AppSettings();
+        config.Bind(settings);
+
+        var foundryLocal = settings.FoundryLocal;
+
+        this.Alias ??= foundryLocal?.Alias;
+
+        for (var i = 0; i < args.Length; i++)
+        {
+            switch (args[i])
+            {
+                case "--alias":
+                    if (i + 1 < args.Length)
+                    {
+                        this.Alias = args[++i];
+                    }
+                    break;
+
+                default:
+                    break;
+            }
+        }
+    }
 }

--- a/test/OpenChat.PlaygroundApp.Tests/Options/FoundryLocalArgumentOptionsTests.cs
+++ b/test/OpenChat.PlaygroundApp.Tests/Options/FoundryLocalArgumentOptionsTests.cs
@@ -1,0 +1,304 @@
+using Microsoft.Extensions.Configuration;
+
+using OpenChat.PlaygroundApp.Abstractions;
+using OpenChat.PlaygroundApp.Connectors;
+
+namespace OpenChat.PlaygroundApp.Tests.Options;
+
+public class FoundryLocalArgumentOptionsTests
+{
+    private const string Alias = "test-foundry-local-alias";
+
+    private static IConfiguration BuildConfigWithFoundryLocal(
+        string? configAlias = Alias,
+        string? envAlias = null
+    )
+    {
+        // Base configuration values (lowest priority)
+        var configDict = new Dictionary<string, string?>
+        {
+            ["ConnectorType"] = ConnectorType.FoundryLocal.ToString(),
+        };
+
+        if (string.IsNullOrWhiteSpace(configAlias) == false)
+        {
+            configDict["FoundryLocal:Alias"] = configAlias;
+        }
+
+        if (string.IsNullOrWhiteSpace(envAlias) == true)
+        {
+            return new ConfigurationBuilder()
+                       .AddInMemoryCollection(configDict!)
+                       .Build();
+        }
+
+        // Environment variables (medium priority)
+        var envDict = new Dictionary<string, string?>();
+        if (string.IsNullOrWhiteSpace(envAlias) == false)
+        {
+            envDict["FoundryLocal:Alias"] = envAlias;
+        }
+
+        return new ConfigurationBuilder()
+                   .AddInMemoryCollection(configDict!)  // Base configuration (lowest priority)
+                   .AddInMemoryCollection(envDict!)     // Environment variables (medium priority)
+                   .Build();
+    }
+
+    [Trait("Category", "UnitTest")]
+    [Fact]
+    public void Given_Nothing_When_Parse_Invoked_Then_It_Should_Set_Config()
+    {
+        // Arrange
+        var config = BuildConfigWithFoundryLocal();
+        var args = Array.Empty<string>();
+
+        // Act
+        var settings = ArgumentOptions.Parse(config, args);
+
+        // Assert
+        settings.FoundryLocal.ShouldNotBeNull();
+        settings.FoundryLocal.Alias.ShouldBe(Alias);
+    }
+
+    [Trait("Category", "UnitTest")]
+    [Theory]
+    [InlineData("cli-foundry-local-alias")]
+    public void Given_CLI_Alias_When_Parse_Invoked_Then_It_Should_Use_CLI_Alias(string cliAlias)
+    {
+        // Arrange
+        var config = BuildConfigWithFoundryLocal();
+        var args = new[] { "--alias", cliAlias };
+
+        // Act
+        var settings = ArgumentOptions.Parse(config, args);
+
+        // Assert
+        settings.FoundryLocal.ShouldNotBeNull();
+        settings.FoundryLocal.Alias.ShouldBe(cliAlias);
+    }
+
+    [Trait("Category", "UnitTest")]
+    [Theory]
+    [InlineData("--alias")]
+    public void Given_CLI_ArgumentWithoutValue_When_Parse_Invoked_Then_It_Should_Use_Config(string argument)
+    {
+        // Arrange
+        var config = BuildConfigWithFoundryLocal();
+        var args = new[] { argument };
+
+        // Act
+        var settings = ArgumentOptions.Parse(config, args);
+
+        // Assert
+        settings.FoundryLocal.ShouldNotBeNull();
+        settings.FoundryLocal.Alias.ShouldBe(Alias);
+    }
+
+    [Trait("Category", "UnitTest")]
+    [Theory]
+    [InlineData("--something", "else", "--another", "value")]
+    public void Given_Unrelated_CLI_Arguments_When_Parse_Invoked_Then_It_Should_Use_Config(params string[] args)
+    {
+        // Arrange
+        var config = BuildConfigWithFoundryLocal();
+
+        // Act
+        var settings = ArgumentOptions.Parse(config, args);
+
+        // Assert
+        settings.FoundryLocal.ShouldNotBeNull();
+        settings.FoundryLocal.Alias.ShouldBe(Alias);
+    }
+
+    [Trait("Category", "UnitTest")]
+    [Theory]
+    [InlineData("--strange-alias-name")]
+    public void Given_FoundryLocal_With_AliasName_StartingWith_Dashes_When_Parse_Invoked_Then_It_Should_Treat_As_Value(string alias)
+    {
+        // Arrange
+        var config = BuildConfigWithFoundryLocal();
+        var args = new[] { "--alias", alias };
+
+        // Act
+        var settings = ArgumentOptions.Parse(config, args);
+
+        // Assert
+        settings.FoundryLocal.ShouldNotBeNull();
+        settings.FoundryLocal.Alias.ShouldBe(alias);
+    }
+
+    [Trait("Category", "UnitTest")]
+    [Theory]
+    [InlineData("config-foundry-local-alias")]
+    public void Given_ConfigValues_And_No_CLI_When_Parse_Invoked_Then_It_Should_Use_Config(string configAlias)
+    {
+        // Arrange
+        var config = BuildConfigWithFoundryLocal(configAlias);
+        var args = Array.Empty<string>();
+
+        // Act
+        var settings = ArgumentOptions.Parse(config, args);
+
+        // Assert
+        settings.FoundryLocal.ShouldNotBeNull();
+        settings.FoundryLocal.Alias.ShouldBe(configAlias);
+    }
+
+    [Trait("Category", "UnitTest")]
+    [Theory]
+    [InlineData("config-foundry-local-alias", "cli-foundry-local-alias")]
+    public void Given_ConfigValues_And_CLI_When_Parse_Invoked_Then_It_Should_Use_CLI(
+        string configAlias, string cliAlias)
+    {
+        // Arrange
+        var config = BuildConfigWithFoundryLocal(configAlias);
+        var args = new[] { "--alias", cliAlias };
+
+        // Act
+        var settings = ArgumentOptions.Parse(config, args);
+
+        // Assert
+        settings.FoundryLocal.ShouldNotBeNull();
+        settings.FoundryLocal.Alias.ShouldBe(cliAlias);
+    }
+
+    [Trait("Category", "UnitTest")]
+    [Theory]
+    [InlineData("env-foundry-local-alias")]
+    public void Given_EnvironmentVariables_And_No_Config_When_Parse_Invoked_Then_It_Should_Use_EnvironmentVariables(
+        string envAlias)
+    {
+        // Arrange
+        var config = BuildConfigWithFoundryLocal(
+            configAlias: null,
+            envAlias: envAlias
+        );
+        var args = Array.Empty<string>();
+
+        // Act
+        var settings = ArgumentOptions.Parse(config, args);
+
+        // Assert
+        settings.FoundryLocal.ShouldNotBeNull();
+        settings.FoundryLocal.Alias.ShouldBe(envAlias);
+    }
+
+    [Trait("Category", "UnitTest")]
+    [Theory]
+    [InlineData("config-foundry-local-alias", "env-foundry-local-alias")]
+    public void Given_ConfigValues_And_EnvironmentVariables_When_Parse_Invoked_Then_It_Should_Use_EnvironmentVariables(
+        string configAlias, string envAlias)
+    {
+        // Arrange
+        var config = BuildConfigWithFoundryLocal(configAlias, envAlias);
+        var args = Array.Empty<string>();
+
+        // Act
+        var settings = ArgumentOptions.Parse(config, args);
+
+        // Assert
+        settings.FoundryLocal.ShouldNotBeNull();
+        settings.FoundryLocal.Alias.ShouldBe(envAlias);
+    }
+
+    [Trait("Category", "UnitTest")]
+    [Theory]
+    [InlineData("config-foundry-local-alias", "env-foundry-local-alias", "cli-foundry-local-alias")]
+    public void Given_ConfigValues_And_EnvironmentVariables_And_CLI_When_Parse_Invoked_Then_It_Should_Use_CLI(
+        string configAlias, string envAlias, string cliAlias)
+    {
+        // Arrange
+        var config = BuildConfigWithFoundryLocal(configAlias, envAlias);
+        var args = new[] { "--alias", cliAlias };
+
+        // Act
+        var settings = ArgumentOptions.Parse(config, args);
+
+        // Assert
+        settings.FoundryLocal.ShouldNotBeNull();
+        settings.FoundryLocal.Alias.ShouldBe(cliAlias);
+    }
+
+    [Trait("Category", "UnitTest")]
+    [Theory]
+    [InlineData("cli-foundry-local-alias")]
+    public void Given_FoundryLocal_With_KnownArguments_When_Parse_Invoked_Then_Help_Should_Be_False(string cliAlias)
+    {
+        // Arrange
+        var config = BuildConfigWithFoundryLocal();
+        var args = new[] { "--alias", cliAlias };
+
+        // Act
+        var settings = ArgumentOptions.Parse(config, args);
+
+        // Assert
+        settings.Help.ShouldBeFalse();
+    }
+
+    [Trait("Category", "UnitTest")]
+    [Theory]
+    [InlineData("--alias")]
+    public void Given_FoundryLocal_With_KnownArgument_WithoutValue_When_Parse_Invoked_Then_Help_Should_Be_False(string argument)
+    {
+        // Arrange
+        var config = BuildConfigWithFoundryLocal();
+        var args = new[] { argument };
+
+        // Act
+        var settings = ArgumentOptions.Parse(config, args);
+
+        // Assert
+        settings.Help.ShouldBeFalse();
+    }
+
+    [Trait("Category", "UnitTest")]
+    [Theory]
+    [InlineData("cli-foundry-local-alias", "--unknown-flag")]
+    public void Given_FoundryLocal_With_Known_And_Unknown_Argument_When_Parse_Invoked_Then_Help_Should_Be_True(string cliAlias, string argument)
+    {
+        // Arrange
+        var config = BuildConfigWithFoundryLocal();
+        var args = new[] { "--alias", cliAlias, argument };
+
+        // Act
+        var settings = ArgumentOptions.Parse(config, args);
+
+        // Assert
+        settings.Help.ShouldBeTrue();
+    }
+
+    [Trait("Category", "UnitTest")]
+    [Theory]
+    [InlineData("env-foundry-local-alias")]
+    public void Given_EnvironmentVariables_Only_When_Parse_Invoked_Then_Help_Should_Be_False(string envAlias)
+    {
+        // Arrange
+        var config = BuildConfigWithFoundryLocal(
+            configAlias: null,
+            envAlias: envAlias);
+        var args = Array.Empty<string>();
+
+        // Act
+        var settings = ArgumentOptions.Parse(config, args);
+
+        // Assert
+        settings.Help.ShouldBeFalse();
+    }
+
+    [Trait("Category", "UnitTest")]
+    [Theory]
+    [InlineData("cli-foundry-local-alias")]
+    public void Given_CLI_Only_When_Parse_Invoked_Then_Help_Should_Be_False(string cliAlias)
+    {
+        // Arrange
+        var config = BuildConfigWithFoundryLocal();
+        var args = new[] { "--alias", cliAlias };
+
+        // Act
+        var settings = ArgumentOptions.Parse(config, args);
+
+        // Assert
+        settings.Help.ShouldBeFalse();
+    }
+}


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* ...

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] New feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## README updated?

The top-level readme for this repo contains a link to each sample in the repo. If you're adding a new sample did you update the readme?
<!-- Mark one with an "x". -->
```
[ ] Yes
[ ] No
[x] N/A
```

## How to Test
*  Get the code

```
git clone https://github.com/ummjevel/open-chat-playground.git
cd open-chat-playground
git checkout feature/332-cmdargmodeling-foundrylocal
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
dotnet build
dotnet test --filter "FoundryLocalArgumentOptionsTests"
```

## What to Check
Verify that the following are valid
- FoundryLocalArgumentOptions class properly inherits from ArgumentOptions
- --alias command-line argument is parsed correctly
- Configuration binding works with FoundryLocalSettings
- ParseOptions method follows the same pattern as HuggingFaceArgumentOptions
- Alias property can be set via both configuration and command-line arguments
- Command-line argument priority works (CLI > Environment > Config)

## Other Information
 - Added FoundryLocalArgumentOptions.cs with --alias support
  - Created FoundryLocalArgumentOptionsTests.cs with 15 test cases
  - Updated ArgumentOptions.cs to register FoundryLocal arguments
  - Follows same pattern as HuggingFaceArgumentOptions
<!-- Add any other helpful information that may be needed here. -->