### PR TITLE
Command-Line Argument Parsing: Exaone #250

### DIFF
--- a/src/OpenChat.PlaygroundApp/Options/LGArgumentOptions.cs
+++ b/src/OpenChat.PlaygroundApp/Options/LGArgumentOptions.cs
@@ -1,0 +1,17 @@
+namespace OpenChat.PlaygroundApp.Options;
+
+/// <summary>
+/// Represents the command-line argument options for LG AI EXAONE.
+/// </summary>
+public class LGArgumentOptions
+{
+    /// <summary>
+    /// Gets or sets the base URL for LG AI EXAONE API.
+    /// </summary>
+    public string? BaseUrl { get; set; }
+
+    /// <summary>
+    /// Gets or sets the model name for LG AI EXAONE.
+    /// </summary>
+    public string? Model { get; set; }
+}

--- a/src/OpenChat.PlaygroundApp/Options/LGArgumentOptions.cs
+++ b/src/OpenChat.PlaygroundApp/Options/LGArgumentOptions.cs
@@ -1,9 +1,10 @@
+using OpenChat.PlaygroundApp.Abstractions;
 namespace OpenChat.PlaygroundApp.Options;
 
 /// <summary>
 /// Represents the command-line argument options for LG AI EXAONE.
 /// </summary>
-public class LGArgumentOptions
+public class LGArgumentOptions : ArgumentOptions
 {
     /// <summary>
     /// Gets or sets the base URL for LG AI EXAONE API.


### PR DESCRIPTION
Closes #250 

## Purpose
Command-Line Argument Options Modelling: LG AI EXAONE

## Does this introduce a breaking change?
- [ ] Yes
- [x] No

## Pull Request Type
What kind of change does this Pull Request introduce?

- [ ] Bugfix
- [x] New feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## README updated?
The top-level readme for this repo contains a link to each sample in the repo. If you're adding a new sample did you update the readme?

- [ ] Yes
- [ ] No
- [x] N/A

## Get the code
```bash
git clone https://github.com/jh941213/open-chat-playground.git
cd open-chat-playground
git checkout feat/344-Command-Line-Argument-Options-Modelling-LG
```

## What to Check
Verify that the following are valid

- [ ] Check if the command line arguments include baseurl and model name.
- [ ] By ArgumentOption.cs, the class name must be `LGArgumentOptions`
- [ ] Whether it follows the same pattern as `OllamaArgumentOptions` (simple structure without inheriting ArgumentOptions)

## Implementation Details
- Created `LGArgumentOptions.cs` in `src/OpenChat.PlaygroundApp/Options/` directory
- Follows the same simple pattern as `OllamaArgumentOptions`
- Includes `BaseUrl` and `Model` properties for LG AI EXAONE configuration
- Does not inherit from `ArgumentOptions` base class (matching Ollama implementation)

## Files Changed
- `src/OpenChat.PlaygroundApp/Options/LGArgumentOptions.cs` (new file)