### PR TITLE
Model Class Implementation: LG AI EXAONE #250

### DIFF
--- a/src/OpenChat.PlaygroundApp/Configurations/LGSettings.cs
+++ b/src/OpenChat.PlaygroundApp/Configurations/LGSettings.cs
@@ -1,0 +1,28 @@
+using OpenChat.PlaygroundApp.Abstractions;
+
+namespace OpenChat.PlaygroundApp.Configurations;
+
+/// <inheritdoc/>
+public partial class AppSettings
+{
+    /// <summary>
+    /// Gets or sets the <see cref="LGSettings"/> instance.
+    /// </summary>
+    public LGSettings? LG { get; set; }
+}
+
+/// <summary>
+/// This represents the app settings entity for LG AI EXAONE.
+/// </summary>
+public class LGSettings : LanguageModelSettings
+{
+    /// <summary>
+    /// Gets or sets the base URL of the LG AI EXAONE API.
+    /// </summary>
+    public string? BaseUrl { get; set; }
+
+    /// <summary>
+    /// Gets or sets the model name for LG AI EXAONE.
+    /// </summary>
+    public string? Model { get; set; }
+}


### PR DESCRIPTION

## Purpose
Implements Command-Line Argument Options and Model Settings for LG AI EXAONE integration
- Adds support for LG AI EXAONE in the OpenChat Playground application
- Creates necessary configuration classes to handle LG AI EXAONE API settings

#250 closes

## Does this introduce a breaking change?
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

```
[ ] Bugfix
[x] New feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## README updated?
The top-level readme for this repo contains a link to each sample in the repo. If you're adding a new sample did you update the readme?

```
[ ] Yes
[ ] No
[x] N/A
```

## How to Test
### Get the code
```bash
git clone https://github.com/jh941213/open-chat-playground.git
cd open-chat-playground
git checkout feature/250
```

### Test the code
```
```

## What to Check
Verify that the following are valid:
- Check if the LG configuration section exists in appsettings.json
- Verify LGSettings class properly inherits from LanguageModelSettings
- Confirm LGSettings maps to the "LG" section in appsettings.json with BaseUrl and Model properties
- Validate that the AppSettings partial class includes the LG property

## Other Information
- This PR addresses issue #250 for LG AI EXAONE integration
- Created `LGSettings.cs` in `src/OpenChat.PlaygroundApp/Configurations/` directory
- The implementation follows the existing pattern used by other providers (Ollama, HuggingFace, etc.)
- Settings class includes BaseUrl and Model properties to support LG AI EXAONE API configuration
- Ready for integration with the broader LG AI EXAONE connector implementation