### PR TITLE
Fix : 295 no streaming response

### DIFF
--- a/src/OpenChat.PlaygroundApp/Components/Pages/Chat/Chat.razor
+++ b/src/OpenChat.PlaygroundApp/Components/Pages/Chat/Chat.razor
@@ -49,11 +49,12 @@
         var responseText = new TextContent("");
         currentResponseMessage = new ChatMessage(ChatRole.Assistant, [responseText]);
         currentResponseCancellation = new();
+
         await foreach (var update in ChatClient.GetStreamingResponseAsync([.. messages], chatOptions, currentResponseCancellation.Token))
         {
             messages.AddMessages(update, filter: c => c is not TextContent);
             responseText.Text += update.Text;
-            ChatMessageItem.NotifyChanged(currentResponseMessage);
+            StateHasChanged();
         }
 
         // Store the final response in the conversation, and begin getting suggestions

--- a/src/OpenChat.PlaygroundApp/Components/Pages/Chat/Chat.razor
+++ b/src/OpenChat.PlaygroundApp/Components/Pages/Chat/Chat.razor
@@ -50,13 +50,14 @@
         currentResponseMessage = new ChatMessage(ChatRole.Assistant, [responseText]);
         currentResponseCancellation = new();
 
+        await InvokeAsync(StateHasChanged);
+
         await foreach (var update in ChatClient.GetStreamingResponseAsync([.. messages], chatOptions, currentResponseCancellation.Token))
         {
             messages.AddMessages(update, filter: c => c is not TextContent);
             responseText.Text += update.Text;
-            StateHasChanged();
+            ChatMessageItem.NotifyChanged(currentResponseMessage);
         }
-
         // Store the final response in the conversation, and begin getting suggestions
         messages.Add(currentResponseMessage!);
         currentResponseMessage = null;

--- a/test/OpenChat.PlaygroundApp.Tests/Components/Pages/Chat/ChatStreamingUITest.cs
+++ b/test/OpenChat.PlaygroundApp.Tests/Components/Pages/Chat/ChatStreamingUITest.cs
@@ -1,0 +1,56 @@
+using Microsoft.Playwright;
+using Microsoft.Playwright.Xunit;
+
+namespace OpenChat.PlaygroundApp.Tests.Components.Pages.Chat;
+
+public class ChatStreamingUITest : PageTest
+{
+    public override async Task InitializeAsync()
+    {
+        await base.InitializeAsync();
+        await Page.GotoAsync(TestConstants.LocalhostUrl);
+        await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+    }
+
+    [Trait("Category", "IntegrationTest")]
+    [Trait("Category", "LLMRequired")]
+    [Theory]
+    [InlineData("하늘은 왜 푸른 색인가요?")]
+    [InlineData("Why is the sky blue?")]
+    public async Task Given_UserMessage_When_SendButton_Clicked_Then_Response_Should_Stream_Progressively(string userMessage)
+    {
+        // Arrange
+        var textArea = Page.GetByRole(AriaRole.Textbox, new() { Name = "User Message Textarea" });
+        var sendButton = Page.GetByRole(AriaRole.Button, new() { Name = "User Message Send Button" });
+
+        // Act
+        await textArea.FillAsync(userMessage);
+        await sendButton.ClickAsync();
+
+        // Assert: Wait for the assistant message container to appear
+        var messageSelector = ".assistant-message-text";
+        await Page.WaitForSelectorAsync(messageSelector);
+
+        // Check that the message content grows over time (streaming)
+        string previousContent = "";
+        bool streamed = false;
+        for (int i = 0; i < 10; i++)
+        {
+            var content = await Page.Locator(messageSelector).InnerTextAsync();
+            if (content.Length > previousContent.Length)
+            {
+                streamed = true;
+                break;
+            }
+            previousContent = content;
+            await Task.Delay(500); // Wait for more content to stream in
+        }
+        Assert.True(streamed, "Response should stream progressively, not appear all at once.");
+    }
+
+    public override async Task DisposeAsync()
+    {
+        await Page.CloseAsync();
+        await base.DisposeAsync();
+    }
+}


### PR DESCRIPTION
## Purpose
* 채팅 답변의 스트리밍 UI가 정상적으로 동작하도록 로직을 수정했습니다.
* Playwright 기반의 스트리밍 UI 테스트 코드를 추가하여, 답변이 점진적으로 표시되는지 검증합니다.

## Does this introduce a breaking change?
```
[ ] Yes
[x] No
```

## Pull Request Type
```
[x] Bugfix
[ ] New feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## README updated?
```
[ ] Yes
[x] No
[ ] N/A
```

## How to Test
*  Get the code

```
git clone https://github.com/jisunchung/open-chat-playground.git
cd open-chat-playground
git checkout fix/295-no-streaming-response
```

* Test the code
```
dotnet run --project src/OpenChat.PlaygroundApp
dotnet test --filter FullyQualifiedName~OpenChat.PlaygroundApp.Tests.Components.Pages.Chat.ChatStreamingUITest
```

## What to Check
* 채팅 답변이 UI에 점진적으로 표시되는지 직접 확인
* 스트리밍 테스트가 성공적으로 통과하는지 확인

## Other Information
* 해당 이슈 수정으로 LoadingSpinner bug도 해결되었습니다. LoadingSpinner에 대한 test도 ChatStreamingUITest에 추가할 수 있습니다.
