### PR TITLE
LG AI EXAONE command-line argument parsing

### DIFF
--- a/src/OpenChat.PlaygroundApp/Abstractions/ArgumentOptions.cs
+++ b/src/OpenChat.PlaygroundApp/Abstractions/ArgumentOptions.cs
@@ -36,6 +36,8 @@ public abstract class ArgumentOptions
         (ConnectorType.Anthropic, "--api-key", false),
         (ConnectorType.Anthropic, "--model", false),
         // LG
+        (ConnectorType.LG, "--base-url", false),
+        (ConnectorType.LG, "--model", false),
         // Naver
         // OpenAI
         (ConnectorType.OpenAI, "--api-key", false),
@@ -197,8 +199,11 @@ public abstract class ArgumentOptions
                 settings.Anthropic.Model = anthropic.Model ?? settings.Anthropic.Model;
                 break;
 
-            // case LGArgumentOptions lg:
-            //     break;
+            case LGArgumentOptions lg:
+                settings.LG ??= new LGSettings();
+                settings.LG.BaseUrl = lg.BaseUrl ?? settings.LG.BaseUrl;
+                settings.LG.Model = lg.Model ?? settings.LG.Model;
+                break;
 
             // case NaverArgumentOptions naver:
             //     break;

--- a/src/OpenChat.PlaygroundApp/Options/LGArgumentOptions.cs
+++ b/src/OpenChat.PlaygroundApp/Options/LGArgumentOptions.cs
@@ -1,4 +1,5 @@
 using OpenChat.PlaygroundApp.Abstractions;
+using OpenChat.PlaygroundApp.Configurations;
 
 namespace OpenChat.PlaygroundApp.Options;
 
@@ -16,4 +17,38 @@ public class LGArgumentOptions : ArgumentOptions
     /// Gets or sets the model name for LG AI EXAONE.
     /// </summary>
     public string? Model { get; set; }
+
+    protected override void ParseOptions(IConfiguration config, string[] args)
+    {
+        var settings = new AppSettings();
+        config.Bind(settings);
+
+        var lg = settings.LG;
+
+        this.BaseUrl ??= lg?.BaseUrl;
+        this.Model ??= lg?.Model;
+
+        for (var i = 0; i < args.Length; i++)
+        {
+            switch (args[i])
+            {
+                case "--base-url":
+                    if (i + 1 < args.Length)
+                    {
+                        this.BaseUrl = args[++i];
+                    }
+                    break;
+
+                case "--model":
+                    if (i + 1 < args.Length)
+                    {
+                        this.Model = args[++i];
+                    }
+                    break;
+
+                default:
+                    break;
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Implements command-line argument parsing for LG AI EXAONE connector
* Adds `LGArgumentOptions` class that inherits from `ArgumentOptions` base class
* Enables parsing of `--base-url` and `--model` command-line arguments for LG AI EXAONE
* Integrates LG argument parsing into the main `ArgumentOptions.Parse` method
* Supports configuration priority: CLI arguments > Configuration file settings
#251 closed

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] New feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## README updated?

The top-level readme for this repo contains a link to each sample in the repo. If you're adding a new sample did you update the readme?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
[ ] N/A
```

## How to Test
*  Get the code

```
git clone https://github.com/jh941213/open-chat-playground.git
cd open-chat-playground
git checkout feature/251
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
dotnet test --filter Category=UnitTest
```

## What to Check
Verify that the following are valid
* Check if the command line arguments include `--base-url` and `--model` for LG AI EXAONE
* Verify that `LGArgumentOptions` class inherits from `ArgumentOptions`
* Confirm that LG arguments are properly parsed and integrated into `AppSettings`
* Ensure all existing tests continue to pass (289 tests should succeed)
* Validate that LG-specific tests cover configuration priority and edge cases
* Check that LG connector is positioned correctly in the Vendor section (after Anthropic, before Naver/OpenAI)
