### PR TITLE
Fix: 296 no loading spinner

### DIFF
--- a/src/OpenChat.PlaygroundApp/Components/Pages/Chat/ChatMessageItem.razor
+++ b/src/OpenChat.PlaygroundApp/Components/Pages/Chat/ChatMessageItem.razor
@@ -28,6 +28,10 @@ else if (Message.Role == ChatRole.Assistant)
                 </div>
             </div>
         }
+        else if (InProgress && content is TextContent { Text: "" })
+        {
+            <LoadingSpinner />
+        }
     }
 }
 

--- a/src/OpenChat.PlaygroundApp/Components/Pages/Chat/ChatMessageList.razor
+++ b/src/OpenChat.PlaygroundApp/Components/Pages/Chat/ChatMessageList.razor
@@ -10,7 +10,6 @@
         @if (InProgressMessage is not null)
         {
             <ChatMessageItem Message="@InProgressMessage" InProgress="true" />
-            <LoadingSpinner />
         }
         else if (IsEmpty)
         {

--- a/test/OpenChat.PlaygroundApp.Tests/Components/Pages/Chat/ChatStreamingUITest.cs
+++ b/test/OpenChat.PlaygroundApp.Tests/Components/Pages/Chat/ChatStreamingUITest.cs
@@ -47,6 +47,35 @@ public class ChatStreamingUITest : PageTest
         finalContent.Length.ShouldBeGreaterThan(initialContent.Length); 
     }
 
+    [Trait("Category", "IntegrationTest")]
+    [Trait("Category", "LLMRequired")]
+    [Theory]
+    [InlineData("하늘은 왜 푸른 색인가요?")]
+    [InlineData("Why is the sky blue?")]
+    public async Task Given_UserMessage_When_SendButton_Clicked_Then_LoadingSpinner_Should_Appear_And_Disappear_When_Text_Arrives(string userMessage)
+    {
+        // Arrange
+        const int timeoutMs = 5000;
+
+        const string spinnerSelector = ".lds-ellipsis";
+        const string messageSelector = ".assistant-message-text";
+
+        var textArea = Page.GetByRole(AriaRole.Textbox, new() { Name = "User Message Textarea" });
+        var sendButton = Page.GetByRole(AriaRole.Button, new() { Name = "User Message Send Button" });
+        var spinner = Page.Locator(spinnerSelector);
+        var message = Page.Locator(messageSelector);
+
+        // Act
+        await textArea.FillAsync(userMessage);
+        await sendButton.ClickAsync();
+
+        // Assert
+        await Expect(spinner).ToBeVisibleAsync(new() { Timeout = timeoutMs });
+
+        await Expect(message).Not.ToHaveTextAsync(string.Empty, new() { Timeout = timeoutMs });
+        await Expect(spinner).Not.ToBeVisibleAsync(new() { Timeout = timeoutMs });
+    }
+
     public override async Task DisposeAsync()
     {
         await Page.CloseAsync();


### PR DESCRIPTION
## Purpose
- Fixes a UI bug where the loading spinner for assistant messages remained visible even after streaming text started to appear.
- Now, the loading spinner is only shown while streaming is in progress and no response text has arrived yet. As soon as any text is received, the spinner disappears.

## Does this introduce a breaking change?
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?
```
[x] Bugfix
[ ] New feature
[x] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## README updated?
```
[ ] Yes
[x] No
[ ] N/A
```

## How to Test
1. Get the code
    ```sh
    git clone https://github.com/jisunchung/open-chat-playground.git
    cd open-chat-playground
    git checkout fix/296-no-loading-spinner
    ```
2. Test the code
    ```sh
    dotnet run --project src/OpenChat.PlaygroundApp
    dotnet test --filter FullyQualifiedName~OpenChat.PlaygroundApp.Tests.Components.Pages.Chat.ChatStreamingUITest
    ```

## What to Check
- The loading spinner for assistant messages is only visible before any response text is received.
- As soon as streaming text appears, the spinner disappears.
- No spinner remains after the message is complete.

## Other Information
- The spinner logic was moved from the message list to the message item for more accurate UI state management.
