### PR TITLE
fix: add AccessKeyId and SecretAccessKey arguments for Amazon Bedrock

### DIFF
--- a/src/OpenChat.PlaygroundApp/Abstractions/ArgumentOptions.cs
+++ b/src/OpenChat.PlaygroundApp/Abstractions/ArgumentOptions.cs
@@ -15,7 +15,7 @@ public abstract class ArgumentOptions
         (ConnectorType.AmazonBedrock, "--access-key-id", false),
         (ConnectorType.AmazonBedrock, "--secret-access-key", false),
         (ConnectorType.AmazonBedrock, "--region", false),
-        (ConnectorType.AmazonBedrock, "--model", false),
+        (ConnectorType.AmazonBedrock, "--model-id", false),
         // Azure AI Foundry
         (ConnectorType.AzureAIFoundry, "--endpoint", false),
         (ConnectorType.AzureAIFoundry, "--api-key", false),
@@ -162,7 +162,7 @@ public abstract class ArgumentOptions
                 settings.AmazonBedrock.AccessKeyId = amazonBedrock.AccessKeyId ?? settings.AmazonBedrock.AccessKeyId;
                 settings.AmazonBedrock.SecretAccessKey = amazonBedrock.SecretAccessKey ?? settings.AmazonBedrock.SecretAccessKey;
                 settings.AmazonBedrock.Region = amazonBedrock.Region ?? settings.AmazonBedrock.Region;
-                settings.AmazonBedrock.Model = amazonBedrock.Model ?? settings.AmazonBedrock.Model;
+                settings.AmazonBedrock.ModelId = amazonBedrock.ModelId ?? settings.AmazonBedrock.ModelId;
                 break;
 
             case AzureAIFoundryArgumentOptions azureAIFoundry:
@@ -307,8 +307,8 @@ public abstract class ArgumentOptions
 
         Console.WriteLine("  --access-key-id     The AWSCredentials Access Key ID.");
         Console.WriteLine("  --secret-access-key The AWSCredentials Secret Access Key.");
-        Console.WriteLine("  --region             The AWS region.");
-        Console.WriteLine("  --model              The model ID. Default to 'anthropic.claude-sonnet-4-20250514-v1:0'");
+        Console.WriteLine("  --region            The AWS region.");
+        Console.WriteLine("  --model-id          The model ID. Default to 'anthropic.claude-sonnet-4-20250514-v1:0'");
         Console.WriteLine();
     }
 

--- a/src/OpenChat.PlaygroundApp/Configurations/AmazonBedrockSettings.cs
+++ b/src/OpenChat.PlaygroundApp/Configurations/AmazonBedrockSettings.cs
@@ -34,5 +34,5 @@ public class AmazonBedrockSettings : LanguageModelSettings
     /// <summary>
     /// Gets or sets the model ID for the Amazon Bedrock service.
     /// </summary>
-    public string? Model { get; set; }
+    public string? ModelId { get; set; }
 }

--- a/src/OpenChat.PlaygroundApp/Options/AmazonBedrockArgumentOptions.cs
+++ b/src/OpenChat.PlaygroundApp/Options/AmazonBedrockArgumentOptions.cs
@@ -26,7 +26,7 @@ public class AmazonBedrockArgumentOptions : ArgumentOptions
     /// <summary>
     ///  Gets or sets the model for the Amazon Bedrock service.
     /// </summary>
-    public string? Model { get; set; }
+    public string? ModelId { get; set; }
 
     /// <inheritdoc/>
     protected override void ParseOptions(IConfiguration config, string[] args)
@@ -39,7 +39,7 @@ public class AmazonBedrockArgumentOptions : ArgumentOptions
         this.AccessKeyId ??= amazonBedrock?.AccessKeyId;
         this.SecretAccessKey ??= amazonBedrock?.SecretAccessKey;
         this.Region ??= amazonBedrock?.Region;
-        this.Model ??= amazonBedrock?.Model;
+        this.ModelId ??= amazonBedrock?.ModelId;
 
         for (var i = 0; i < args.Length; i++)
         {
@@ -66,10 +66,10 @@ public class AmazonBedrockArgumentOptions : ArgumentOptions
                     }
                     break;
 
-                case "--model":
+                case "--model-id":
                     if (i + 1 < args.Length)
                     {
-                        this.Model = args[++i];
+                        this.ModelId = args[++i];
                     }
                     break;
 

--- a/src/OpenChat.PlaygroundApp/appsettings.json
+++ b/src/OpenChat.PlaygroundApp/appsettings.json
@@ -15,7 +15,7 @@
     "AccessKeyId": "{{AWS_ACCESS_KEY_ID}}",
     "SecretAccessKey": "{{AWS_SECRET_ACCESS_KEY}}",
     "Region": "{{AWS_REGION}}",
-    "Model": "anthropic.claude-sonnet-4-20250514-v1:0"
+    "ModelId": "anthropic.claude-sonnet-4-20250514-v1:0"
   },
   
   "AzureAIFoundry": {

--- a/test/OpenChat.PlaygroundApp.Tests/Options/AmazonBedrockArgumentOptionsTests.cs
+++ b/test/OpenChat.PlaygroundApp.Tests/Options/AmazonBedrockArgumentOptionsTests.cs
@@ -10,13 +10,13 @@ public class AmazonBedrockArgumentOptionsTests
     private const string AwsAccessKeyId = "test-access-key-id";
     private const string AwsSecretAccessKey = "test-secret-access-key";
     private const string Region = "test-region";
-    private const string Model = "test-model";
+    private const string ModelId = "test-model-id";
 
     private static IConfiguration BuildConfigWithAmazonBedrock(
         string? AwsAccessKeyId = AwsAccessKeyId,
         string? AwsSecretAccessKey = AwsSecretAccessKey,
         string? configRegion = Region,
-        string? configModel = Model)
+        string? configModel = ModelId)
     {
         var configDict = new Dictionary<string, string?>
         {
@@ -37,7 +37,7 @@ public class AmazonBedrockArgumentOptionsTests
         }
         if (string.IsNullOrWhiteSpace(configModel) == false)
         {
-            configDict["AmazonBedrock:Model"] = configModel;
+            configDict["AmazonBedrock:ModelId"] = configModel;
         }
 
         // TODO: "envDict" can be added here
@@ -63,7 +63,7 @@ public class AmazonBedrockArgumentOptionsTests
         settings.AmazonBedrock.AccessKeyId.ShouldBe(AwsAccessKeyId);
         settings.AmazonBedrock.SecretAccessKey.ShouldBe(AwsSecretAccessKey);
         settings.AmazonBedrock.Region.ShouldBe(Region);
-        settings.AmazonBedrock.Model.ShouldBe(Model);
+        settings.AmazonBedrock.ModelId.ShouldBe(ModelId);
     }
 
     [Trait("Category", "UnitTest")]
@@ -83,7 +83,7 @@ public class AmazonBedrockArgumentOptionsTests
         settings.AmazonBedrock.AccessKeyId.ShouldBe(cliAccessKeyId);
         settings.AmazonBedrock.SecretAccessKey.ShouldBe(AwsSecretAccessKey);
         settings.AmazonBedrock.Region.ShouldBe(Region);
-        settings.AmazonBedrock.Model.ShouldBe(Model);
+        settings.AmazonBedrock.ModelId.ShouldBe(ModelId);
     }
 
     [Trait("Category", "UnitTest")]
@@ -103,7 +103,7 @@ public class AmazonBedrockArgumentOptionsTests
         settings.AmazonBedrock.AccessKeyId.ShouldBe(AwsAccessKeyId);
         settings.AmazonBedrock.SecretAccessKey.ShouldBe(cliSecretAccessKey);
         settings.AmazonBedrock.Region.ShouldBe(Region);
-        settings.AmazonBedrock.Model.ShouldBe(Model);
+        settings.AmazonBedrock.ModelId.ShouldBe(ModelId);
     }
 
     [Trait("Category", "UnitTest")]
@@ -123,17 +123,17 @@ public class AmazonBedrockArgumentOptionsTests
         settings.AmazonBedrock.AccessKeyId.ShouldBe(AwsAccessKeyId);
         settings.AmazonBedrock.SecretAccessKey.ShouldBe(AwsSecretAccessKey);
         settings.AmazonBedrock.Region.ShouldBe(cliRegion);
-        settings.AmazonBedrock.Model.ShouldBe(Model);
+        settings.AmazonBedrock.ModelId.ShouldBe(ModelId);
     }
 
     [Trait("Category", "UnitTest")]
     [Theory]
-    [InlineData("cli-model")]
-    public void Given_CLI_Model_When_Parse_Invoked_Then_It_Should_Use_CLI_Model(string cliModel)
+    [InlineData("cli-model-id")]
+    public void Given_CLI_Model_When_Parse_Invoked_Then_It_Should_Use_CLI_Model(string cliModelId)
     {
         // Arrange
         var config = BuildConfigWithAmazonBedrock();
-        var args = new[] { "--model", cliModel };
+        var args = new[] { "--model-id", cliModelId };
 
         // Act
         var settings = ArgumentOptions.Parse(config, args);
@@ -143,17 +143,17 @@ public class AmazonBedrockArgumentOptionsTests
         settings.AmazonBedrock.AccessKeyId.ShouldBe(AwsAccessKeyId);
         settings.AmazonBedrock.SecretAccessKey.ShouldBe(AwsSecretAccessKey);
         settings.AmazonBedrock.Region.ShouldBe(Region);
-        settings.AmazonBedrock.Model.ShouldBe(cliModel);
+        settings.AmazonBedrock.ModelId.ShouldBe(cliModelId);
     }
 
     [Trait("Category", "UnitTest")]
     [Theory]
-    [InlineData("cli-access-key-id", "cli-secret-access-key", "cli-region", "cli-model")]
-    public void Given_All_CLI_Arguments_When_Parse_Invoked_Then_It_Should_Use_CLI(string cliAccessKeyId, string cliSecretAccessKey, string cliRegion, string cliModel)
+    [InlineData("cli-access-key-id", "cli-secret-access-key", "cli-region", "cli-model-id")]
+    public void Given_All_CLI_Arguments_When_Parse_Invoked_Then_It_Should_Use_CLI(string cliAccessKeyId, string cliSecretAccessKey, string cliRegion, string cliModelId)
     {
         // Arrange
         var config = BuildConfigWithAmazonBedrock();
-        var args = new[] { "--access-key-id", cliAccessKeyId, "--secret-access-key", cliSecretAccessKey, "--region", cliRegion, "--model", cliModel };
+        var args = new[] { "--access-key-id", cliAccessKeyId, "--secret-access-key", cliSecretAccessKey, "--region", cliRegion, "--model-id", cliModelId };
 
         // Act
         var settings = ArgumentOptions.Parse(config, args);
@@ -163,7 +163,7 @@ public class AmazonBedrockArgumentOptionsTests
         settings.AmazonBedrock.AccessKeyId.ShouldBe(cliAccessKeyId);
         settings.AmazonBedrock.SecretAccessKey.ShouldBe(cliSecretAccessKey);
         settings.AmazonBedrock.Region.ShouldBe(cliRegion);
-        settings.AmazonBedrock.Model.ShouldBe(cliModel);
+        settings.AmazonBedrock.ModelId.ShouldBe(cliModelId);
     }
 
     [Trait("Category", "UnitTest")]
@@ -171,7 +171,7 @@ public class AmazonBedrockArgumentOptionsTests
     [InlineData("--access-key-id")]
     [InlineData("--secret-access-key")]
     [InlineData("--region")]
-    [InlineData("--model")]
+    [InlineData("--model-id")]
     public void Given_CLI_ArgumentWithoutValue_When_Parse_Invoked_Then_It_Should_Use_Config(string argument)
     {
         // Arrange
@@ -186,7 +186,7 @@ public class AmazonBedrockArgumentOptionsTests
         settings.AmazonBedrock.AccessKeyId.ShouldBe(AwsAccessKeyId);
         settings.AmazonBedrock.SecretAccessKey.ShouldBe(AwsSecretAccessKey);
         settings.AmazonBedrock.Region.ShouldBe(Region);
-        settings.AmazonBedrock.Model.ShouldBe(Model);
+        settings.AmazonBedrock.ModelId.ShouldBe(ModelId);
     }
 
     [Trait("Category", "UnitTest")]
@@ -202,8 +202,10 @@ public class AmazonBedrockArgumentOptionsTests
 
         // Assert
         settings.AmazonBedrock.ShouldNotBeNull();
+        settings.AmazonBedrock.AccessKeyId.ShouldBe(AwsAccessKeyId);
+        settings.AmazonBedrock.SecretAccessKey.ShouldBe(AwsSecretAccessKey);
         settings.AmazonBedrock.Region.ShouldBe(Region);
-        settings.AmazonBedrock.Model.ShouldBe(Model);
+        settings.AmazonBedrock.ModelId.ShouldBe(ModelId);
     }
 
     [Trait("Category", "UnitTest")]
@@ -225,11 +227,11 @@ public class AmazonBedrockArgumentOptionsTests
 
     [Trait("Category", "UnitTest")]
     [Theory]
-    [InlineData("config-access-key-id", "config-secret-access-key", "config-region", "config-model")]
-    public void Given_ConfigValues_And_No_CLI_When_Parse_Invoked_Then_It_Should_Use_Config(string configAccessKeyId, string configSecretAccessKey, string configRegion, string configModel)
+    [InlineData("config-access-key-id", "config-secret-access-key", "config-region", "config-model-id")]
+    public void Given_ConfigValues_And_No_CLI_When_Parse_Invoked_Then_It_Should_Use_Config(string configAccessKeyId, string configSecretAccessKey, string configRegion, string configModelId)
     {
         // Arrange
-        var config = BuildConfigWithAmazonBedrock(configAccessKeyId, configSecretAccessKey, configRegion, configModel);
+        var config = BuildConfigWithAmazonBedrock(configAccessKeyId, configSecretAccessKey, configRegion, configModelId);
         var args = Array.Empty<string>();
 
         // Act
@@ -240,20 +242,20 @@ public class AmazonBedrockArgumentOptionsTests
         settings.AmazonBedrock.AccessKeyId.ShouldBe(configAccessKeyId);
         settings.AmazonBedrock.SecretAccessKey.ShouldBe(configSecretAccessKey);
         settings.AmazonBedrock.Region.ShouldBe(configRegion);
-        settings.AmazonBedrock.Model.ShouldBe(configModel);
+        settings.AmazonBedrock.ModelId.ShouldBe(configModelId);
     }
 
     [Trait("Category", "UnitTest")]
     [Theory]
-    [InlineData("config-access-key-id", "config-secret-access-key", "config-region", "config-model",
-                "cli-access-key-id", "cli-secret-access-key", "cli-region", "cli-model")]
+    [InlineData("config-access-key-id", "config-secret-access-key", "config-region", "config-model-id",
+                "cli-access-key-id", "cli-secret-access-key", "cli-region", "cli-model-id")]
     public void Given_ConfigValues_And_CLI_When_Parse_Invoked_Then_It_Should_Use_CLI(
-        string configAccessKeyId, string configSecretAccessKey, string configRegion, string configModel,
-        string cliAccessKeyId, string cliSecretAccessKey, string cliRegion, string cliModel)
+        string configAccessKeyId, string configSecretAccessKey, string configRegion, string configModelId,
+        string cliAccessKeyId, string cliSecretAccessKey, string cliRegion, string cliModelId)
     {
         // Arrange
-        var config = BuildConfigWithAmazonBedrock(configAccessKeyId, configSecretAccessKey, configRegion, configModel);
-        var args = new[] { "--access-key-id", cliAccessKeyId, "--secret-access-key", cliSecretAccessKey, "--region", cliRegion, "--model", cliModel };
+        var config = BuildConfigWithAmazonBedrock(configAccessKeyId, configSecretAccessKey, configRegion, configModelId);
+        var args = new[] { "--access-key-id", cliAccessKeyId, "--secret-access-key", cliSecretAccessKey, "--region", cliRegion, "--model-id", cliModelId };
 
         // Act
         var settings = ArgumentOptions.Parse(config, args);
@@ -263,17 +265,17 @@ public class AmazonBedrockArgumentOptionsTests
         settings.AmazonBedrock.AccessKeyId.ShouldBe(cliAccessKeyId);
         settings.AmazonBedrock.SecretAccessKey.ShouldBe(cliSecretAccessKey);
         settings.AmazonBedrock.Region.ShouldBe(cliRegion);
-        settings.AmazonBedrock.Model.ShouldBe(cliModel);
+        settings.AmazonBedrock.ModelId.ShouldBe(cliModelId);
     }
 
     [Trait("Category", "UnitTest")]
     [Theory]
-    [InlineData("cli-access-key-id", "cli-secret-access-key", "cli-region", "cli-model")]
-    public void Given_AmazonBedrock_With_KnownArguments_When_Parse_Invoked_Then_Help_ShouldBe_False(string cliAccessKeyId, string cliSecretAccessKey, string cliRegion, string cliModel)
+    [InlineData("cli-access-key-id", "cli-secret-access-key", "cli-region", "cli-model-id")]
+    public void Given_AmazonBedrock_With_KnownArguments_When_Parse_Invoked_Then_Help_ShouldBe_False(string cliAccessKeyId, string cliSecretAccessKey, string cliRegion, string cliModelId)
     {
         // Arrange
-        var config = BuildConfigWithAmazonBedrock(AwsAccessKeyId, AwsSecretAccessKey, Region, Model);
-        var args = new[] { "--access-key-id", cliAccessKeyId, "--secret-access-key", cliSecretAccessKey, "--region", cliRegion, "--model", cliModel };
+        var config = BuildConfigWithAmazonBedrock(AwsAccessKeyId, AwsSecretAccessKey, Region, ModelId);
+        var args = new[] { "--access-key-id", cliAccessKeyId, "--secret-access-key", cliSecretAccessKey, "--region", cliRegion, "--model-id", cliModelId };
 
         // Act
         var settings = ArgumentOptions.Parse(config, args);
@@ -287,7 +289,7 @@ public class AmazonBedrockArgumentOptionsTests
     [InlineData("--access-key-id")]
     [InlineData("--secret-access-key")]
     [InlineData("--region")]
-    [InlineData("--model")]
+    [InlineData("--model-id")]
     public void Given_AmazonBedrock_With_KnownArgument_WithoutValue_When_Parse_Invoked_Then_Help_ShouldBe_False(string argument)
     {
         // Arrange


### PR DESCRIPTION
Closes #461

## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Amazon Bedrock 커넥터 생성을 위해, `AccessKeyId`, `SecretAccesskey`, `Region`이 필수 값임
* 그러나 현재 프로젝트 상에서 `Region`과 `Model`에 대한 값만 설정하고 있어, 누락된 설정값 추가가 필요함

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] New feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## README updated?

The top-level readme for this repo contains a link to each sample in the repo. If you're adding a new sample did you update the readme?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
[ ] N/A
```

## How to Test
*  Get the code

```
git clone https://github.com/sikutisa/open-chat-playground.git
cd src/OpenChat.PlaygroundApp
git checkout fix/461-amazon-bedrock-connections-infos
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
dotnet test --filter "Category=UnitTest"
```

## What to Check
Verify that the following are valid
- Add `AccessKeyId`, `SecretAccesskey` & Updating all related codes accordingly.
  - [x] `appsettings.json`
  - [x] `ArgumentOptions.cs`
  - [x] `AmazonBedrockSettings.cs`
  - [x] `AmaznoBedrockArgumentsOptions.cs`
- Update related test codes
  - ~[ ] `ArgumentOptionsTest.cs`~
  - [x] `AmazonBedrockArgumentOptions.Test.cs`