### PR TITLE
Connector Implementation & Inheritance: LG AI EXAONE

### DIFF
--- a/src/OpenChat.PlaygroundApp/Abstractions/LanguageModelConnector.cs
+++ b/src/OpenChat.PlaygroundApp/Abstractions/LanguageModelConnector.cs
@@ -37,6 +37,7 @@ public abstract class LanguageModelConnector(LanguageModelSettings? settings)
         LanguageModelConnector connector = settings.ConnectorType switch
         {
             ConnectorType.GitHubModels => new GitHubModelsConnector(settings),
+            ConnectorType.LG => new LGConnector(settings),
             ConnectorType.OpenAI => new OpenAIConnector(settings),
             _ => throw new NotSupportedException($"Connector type '{settings.ConnectorType}' is not supported.")
         };

--- a/src/OpenChat.PlaygroundApp/Connectors/LGConnector.cs
+++ b/src/OpenChat.PlaygroundApp/Connectors/LGConnector.cs
@@ -1,0 +1,53 @@
+using Microsoft.Extensions.AI;
+using OllamaSharp;
+
+using OpenChat.PlaygroundApp.Abstractions;
+using OpenChat.PlaygroundApp.Configurations;
+
+namespace OpenChat.PlaygroundApp.Connectors;
+
+/// <summary>
+/// This represents the connector entity for LG AI EXAONE.
+/// </summary>
+public class LGConnector(AppSettings settings) : LanguageModelConnector(settings.LG)
+{
+    /// <inheritdoc/>
+    public override bool EnsureLanguageModelSettingsValid()
+    {
+        var settings = this.Settings as LGSettings;
+        if (settings is null)
+        {
+            throw new InvalidOperationException("Missing configuration: LG.");
+        }
+
+        if (string.IsNullOrWhiteSpace(settings.BaseUrl!.Trim()) == true)
+        {
+            throw new InvalidOperationException("Missing configuration: LG:BaseUrl.");
+        }
+
+        if (string.IsNullOrWhiteSpace(settings.Model!.Trim()) == true)
+        {
+            throw new InvalidOperationException("Missing configuration: LG:Model.");
+        }
+
+        return true;
+    }
+
+    /// <inheritdoc/>
+    public override async Task<IChatClient> GetChatClientAsync()
+    {
+        var settings = this.Settings as LGSettings;
+        var baseUrl = settings!.BaseUrl!;
+        var model = settings!.Model!;
+
+        var config = new OllamaApiClient.Configuration
+        {
+            Uri = new Uri(baseUrl),
+            Model = model,
+        };
+
+        var chatClient = new OllamaApiClient(config);
+
+        return await Task.FromResult(chatClient).ConfigureAwait(false);
+    }
+}

--- a/test/OpenChat.PlaygroundApp.Tests/Connectors/LGConnectorTests.cs
+++ b/test/OpenChat.PlaygroundApp.Tests/Connectors/LGConnectorTests.cs
@@ -1,0 +1,151 @@
+using OpenChat.PlaygroundApp.Abstractions;
+using OpenChat.PlaygroundApp.Configurations;
+using OpenChat.PlaygroundApp.Connectors;
+
+namespace OpenChat.PlaygroundApp.Tests.Connectors;
+
+public class LGConnectorTests
+{
+    
+    private static AppSettings BuildAppSettings(string? baseUrl = "https://test.lg-exaone/api", string? model = "lg-exaone-model")
+    {
+        return new AppSettings
+        {
+            ConnectorType = ConnectorType.LG,
+            LG = new LGSettings
+            {
+                BaseUrl = baseUrl,
+                Model = model
+            }
+        };
+    }
+
+    [Trait("Category", "UnitTest")]
+    [Theory]
+    [InlineData(typeof(LanguageModelConnector), typeof(LGConnector), true)]
+    [InlineData(typeof(LGConnector), typeof(LanguageModelConnector), false)]
+    public void Given_BaseType_Then_It_Should_Be_AssignableFrom_DerivedType(Type baseType, Type derivedType, bool expected)
+    {
+        // Act
+        var result = baseType.IsAssignableFrom(derivedType);
+
+        // Assert
+        result.ShouldBe(expected);
+    }
+
+    [Trait("Category", "UnitTest")]
+    [Fact]
+    public void Given_Settings_Is_Null_When_EnsureLanguageModelSettingsValid_Invoked_Then_It_Should_Throw()
+    {
+        // Arrange
+        var appSettings = new AppSettings { ConnectorType = ConnectorType.LG, LG = null };
+        var connector = new LGConnector(appSettings);
+
+        // Act
+        Action action = () => connector.EnsureLanguageModelSettingsValid();
+
+        // Assert
+        action.ShouldThrow<InvalidOperationException>()
+            .Message.ShouldContain("LG");
+    }
+
+    [Trait("Category", "UnitTest")]
+    [Theory]
+    [InlineData(null, typeof(NullReferenceException), "Object reference not set to an instance of an object")]
+    [InlineData("", typeof(InvalidOperationException), "LG:BaseUrl")]
+    [InlineData("   ", typeof(InvalidOperationException), "LG:BaseUrl")]
+    public void Given_Invalid_BaseUrl_When_EnsureLanguageModelSettingsValid_Invoked_Then_It_Should_Throw(string? baseUrl, Type expectedType, string expectedMessage)
+    {
+        // Arrange
+        var appSettings = BuildAppSettings(baseUrl: baseUrl);
+        var connector = new LGConnector(appSettings);
+
+        // Act
+        var ex = Assert.Throws(expectedType, () => connector.EnsureLanguageModelSettingsValid());
+
+        // Assert
+        ex.Message.ShouldContain(expectedMessage);
+    }
+
+    [Trait("Category", "UnitTest")]
+    [Theory]
+    [InlineData(null, typeof(NullReferenceException), "Object reference not set to an instance of an object")]
+    [InlineData("", typeof(InvalidOperationException), "LG:Model")]
+    [InlineData("   ", typeof(InvalidOperationException), "LG:Model")]
+    public void Given_Invalid_Model_When_EnsureLanguageModelSettingsValid_Invoked_Then_It_Should_Throw(string? model, Type expectedType, string expectedMessage)
+    {
+        // Arrange
+        var appSettings = BuildAppSettings(model: model);
+        var connector = new LGConnector(appSettings);
+
+        // Act
+        var ex = Assert.Throws(expectedType, () => connector.EnsureLanguageModelSettingsValid());
+
+        // Assert
+        ex.Message.ShouldContain(expectedMessage);
+    }
+
+    [Trait("Category", "UnitTest")]
+    [Fact]
+    public void Given_Valid_Settings_When_EnsureLanguageModelSettingsValid_Invoked_Then_It_Should_Return_True()
+    {
+        // Arrange
+        var appSettings = BuildAppSettings();
+        var connector = new LGConnector(appSettings);
+
+        // Act
+        var result = connector.EnsureLanguageModelSettingsValid();
+
+        // Assert
+        result.ShouldBeTrue();
+    }
+
+    [Trait("Category", "UnitTest")]
+    [Fact]
+    public async Task Given_Valid_Settings_When_GetChatClient_Invoked_Then_It_Should_Return_ChatClient()
+    {
+        // Arrange
+        var settings = BuildAppSettings();
+        var connector = new LGConnector(settings);
+
+        // Act
+        var client = await connector.GetChatClientAsync();
+
+        // Assert
+        client.ShouldNotBeNull();
+    }
+
+    [Trait("Category", "UnitTest")]
+    [Theory]
+    [InlineData(null, typeof(InvalidOperationException), "LG:BaseUrl")]
+    [InlineData("", typeof(UriFormatException), "empty")]
+    public async Task Given_Missing_BaseUrl_When_GetChatClient_Invoked_Then_It_Should_Throw(string? baseUrl, Type expected, string message)
+    {
+        // Arrange
+        var settings = BuildAppSettings(baseUrl: baseUrl);
+        var connector = new LGConnector(settings);
+
+        // Act
+        var ex = await Assert.ThrowsAsync(expected, connector.GetChatClientAsync);
+
+        // Assert
+        ex.Message.ShouldContain(message);
+    }
+
+    [Trait("Category", "UnitTest")]
+    [Theory]
+    [InlineData(null, typeof(ArgumentNullException), "model")]
+    [InlineData("", typeof(ArgumentException), "model")]
+    public async Task Given_Missing_Model_When_GetChatClient_Invoked_Then_It_Should_Throw(string? model, Type expected, string message)
+    {
+        // Arrange
+        var settings = BuildAppSettings(model: model);
+        var connector = new LGConnector(settings);
+
+        // Act
+        var ex = await Assert.ThrowsAsync(expected, connector.GetChatClientAsync);
+
+        // Assert
+        ex.Message.ShouldContain(message);
+    }
+}


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* closes Connector Implementation & Inheritance: LG AI EXAONE #253
* Implement LGConnector class that inherits from LanguageModelConnector
* Add AppSettings dependency injection for LG AI EXAONE configuration
* Override GetChatClient method to provide LG AI EXAONE chat client functionality
* Enable LG AI EXAONE integration through Ollama-compatible API

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] New feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## README updated?

The top-level readme for this repo contains a link to each sample in the repo. If you're adding a new sample did you update the readme?
<!-- Mark one with an "x". -->
```
[ ] Yes
[ ] No
[x] N/A
```

## How to Test
*  Get the code

```
git clone https://github.com/tae0y/open-chat-playground.git
cd open-chat-playground
git checkout feature/253
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
dotnet test test/OpenChat.PlaygroundApp.Tests/OpenChat.PlaygroundApp.Tests.csproj --filter "FullyQualifiedName~LGConnectorTests"
dotnet run --project ./src/OpenChat.PlaygroundApp/ -- --connector-type LG --base-url http://localhost:11434 --model lg-exaone-model
```

## What to Check
Verify that the following are valid
* LGConnector class properly inherits from LanguageModelConnector
* AppSettings dependency injection works correctly for LG configuration
* GetChatClientAsync method returns valid IChatClient instance
* LG connector type is properly registered in LanguageModelConnector.CreateChatClientAsync
* All LGConnectorTests pass successfully
* LG connector integrates seamlessly with existing connector infrastructure

## Other Information
<!-- Add any other helpful information that may be needed here. -->

This implementation follows the same pattern as Ollama connector implementation, using OllamaSharp library for LG AI EXAONE integration. The connector:

- Uses Ollama-compatible API for LG AI EXAONE models
- Requires only BaseUrl and Model configuration (no API key needed for open source models)
- Implements proper validation for required configuration settings
- Provides comprehensive error handling for missing or invalid configurations

Key components added:
- `LGConnector.cs` - Main connector implementation
- `LGConnectorTests.cs` - Comprehensive unit tests
- Updated `LanguageModelConnector.cs` to include LG case in factory method

The implementation enables users to run LG AI EXAONE models through the OpenChat Playground interface using the same infrastructure as other supported connectors.