### PR TITLE
Update playground app title 

### DIFF
--- a/src/OpenChat.PlaygroundApp/Components/Pages/Chat/ChatHeader.razor
+++ b/src/OpenChat.PlaygroundApp/Components/Pages/Chat/ChatHeader.razor
@@ -8,5 +8,5 @@
         </button>
     </div>
 
-    <h1 class="page-width">OpenChat.PlaygroundApp</h1>
+    <h1 class="page-width">OpenChat Playground</h1>
 </div>

--- a/test/OpenChat.PlaygroundApp.Tests/Components/Pages/Chat/ChatHeaderUITests.cs
+++ b/test/OpenChat.PlaygroundApp.Tests/Components/Pages/Chat/ChatHeaderUITests.cs
@@ -14,7 +14,7 @@ public class ChatHeaderUITests : PageTest
 
     [Trait("Category", "IntegrationTest")]
     [Theory]
-    [InlineData("OpenChat.PlaygroundApp")]
+    [InlineData("OpenChat Playground")]
     public async Task Given_Root_Page_When_Loaded_Then_Header_Should_Be_Visible(string expected)
     {
         // Act


### PR DESCRIPTION
## Purpose

* 앱 타이틀을 "OpenChat Playground"로 업데이트
* 랜딩 페이지 헤더와 브라우저 타이틀 바에 일관된 앱 이름 표시
* 앱 타이틀 표시를 검증하는 UI 테스트 업데이트

closes: #370 

## Does this introduce a breaking change?

```
[ ] Yes
[x] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?

```
[ ] Bugfix
[ ] New feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[x] Other... Please describe: Update app title
```

## README updated?

The top-level readme for this repo contains a link to each sample in the repo. If you're adding a new sample did you update the readme?

```
[ ] Yes
[ ] No
[x] N/A
```

* Test the code

<img width="300" alt="test-result" src="https://github.com/user-attachments/assets/9ee30e43-98c5-45fc-9b67-da62d2db1541" />

1. 앱 실행
	```sh
	dotnet run --project src/OpenChat.PlaygroundApp/OpenChat.PlaygroundApp.csproj
	```

2. 테스트 실행
	```sh
	dotnet test test/OpenChat.PlaygroundApp.Tests/OpenChat.PlaygroundApp.Tests.csproj --filter "FullyQualifiedName~ChatHeaderUITests.Given_Root_Page_When_Loaded_Then_Header_Should_Be_Visible|FullyQualifiedName~ChatUITests.Given_Root_Page_When_Loaded_Then_PageTitle_Text_Should_Match"
	```

## What to Check

Verify that the following are valid

* 브라우저 타이틀 바에 "OpenChat Playground"가 표시되는지 확인
* 랜딩 페이지 헤더에 "OpenChat Playground"가 표시되는지 확인
* 앱 타이틀 관련 UI 테스트가 통과하는지 확인

## Other Information

브라우저 타이틀 바나 랜딩 페이지 헤더 말고는 앱 타이틀을 쓰는 곳이 안 보이는데 혹시 빠진 부분이 있다면 알려주세요!