### PR TITLE
feat: add environment variables testing for docker

### DIFF
--- a/test/OpenChat.PlaygroundApp.Tests/Options/DockerModelRunnerArgumentOptionsTests.cs
+++ b/test/OpenChat.PlaygroundApp.Tests/Options/DockerModelRunnerArgumentOptionsTests.cs
@@ -253,7 +253,7 @@ public class DockerModelRunnerArgumentOptionsTests
         settings.DockerModelRunner.Model.ShouldBe(cliModel);
     }
 
-    
+    [Trait("Category", "UnitTest")]
     [Theory]
     [InlineData("http://cli-dmr", "cli-model")]
     public void Given_DockerModelRunner_With_KnownArguments_When_Parse_Invoked_Then_Help_ShouldBe_False(string cliBaseUrl, string cliModel)


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
- close #278

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] New feature
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[] Other... Please describe:
```

## README updated?

The top-level readme for this repo contains a link to each sample in the repo. If you're adding a new sample did you update the readme?
<!-- Mark one with an "x". -->
```
[ ] Yes
[ ] No
[x] N/A
```

## How to Test
*  Get the code

```
git clone https://github.com/jisunchung/open-chat-playground.git
cd open-chat-playground
git checkout feature/278-environment-variables-testing-docker
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
dotnet test --filter Category=UnitTest

```

## What to Check
Verify that the following are valid:

- Environment variables are correctly converted to a dedicated object instance.
- Environment variables have higher priority than config, but lower priority than command-line arguments.
- Environment variable names are consistent across all projects.
- Run tests – Execute all FoundryLocal tests to ensure they pass.
- Code style check – Verify formatting matches existing codebase standards.
- Test coverage – Confirm all environment variable scenarios are covered.

## Other Information
<!-- Add any other helpful information that may be needed here. -->
Added test methods(DockerModelRunnerArgumentOptionsTests.cs):

`Given_CLI_Only_When_Parse_Invoked_Then_Help_Should_Be_False`
`Given_EnvironmentVariables_And_No_Config_When_Parse_Invoked_Then_It_Should_Use_EnvironmentVariables`
`Given_ConfigValues_And_EnvironmentVariables_When_Parse_Invoked_Then_It_Should_Use_EnvironmentVariables`
`Given_ConfigValues_And_EnvironmentVariables_And_CLI_When_Parse_Invoked_Then_It_Should_Use_CLI`
`Given_Partial_EnvironmentVariables_When_Parse_Invoked_Then_It_Should_Mix_Config_And_Environment`
`Given_EnvironmentVariables_Only_When_Parse_Invoked_Then_Help_Should_Be_False`