### PR TITLE
Update docker-model-runner.md

### DIFF
--- a/docs/docker-model-runner.md
+++ b/docs/docker-model-runner.md
@@ -18,13 +18,25 @@ This page describes how to run OpenChat Playground (OCP) with [Docker Model Runn
 
 ## Run on local machine
 
-1. Make sure the Docker Model Runner is up and running with the following command.
+1. Make sure the Docker Model Runner is up and ready to accept requests with the following command.
 
     ```bash
     docker model status
     ```
 
    It should say `Docker Model Runner is running`.
+
+    ```bash
+    curl http://localhost:12434
+    ```
+
+    ```powershell
+    Invoke-WebRequest http://localhost:12434
+    ```
+
+    It should say `The Service is running`
+
+    > If it says `Connection refused`, turn on "Enable host-side TCP support" option in Docker Desktop Settings.
 
 1. Download the model. The default model OCP uses is [ai/smollm2](https://hub.docker.com/r/ai/smollm2).
 

--- a/docs/docker-model-runner.md
+++ b/docs/docker-model-runner.md
@@ -32,7 +32,7 @@ This page describes how to run OpenChat Playground (OCP) with [Docker Model Runn
     ```
 
     ```powershell
-    # {owershell
+    # Powershell
     Invoke-WebRequest http://localhost:12434
     ```
 
@@ -90,7 +90,7 @@ This page describes how to run OpenChat Playground (OCP) with [Docker Model Runn
     ```
 
     ```powershell
-    # {owershell
+    # Powershell
     Invoke-WebRequest http://localhost:12434
     ```
 

--- a/docs/docker-model-runner.md
+++ b/docs/docker-model-runner.md
@@ -27,16 +27,18 @@ This page describes how to run OpenChat Playground (OCP) with [Docker Model Runn
    It should say `Docker Model Runner is running`.
 
     ```bash
+    # bash/zsh
     curl http://localhost:12434
     ```
 
     ```powershell
+    # {owershell
     Invoke-WebRequest http://localhost:12434
     ```
 
     It should say `The Service is running`
 
-    > If it says `Connection refused`, turn on "Enable host-side TCP support" option in Docker Desktop Settings.
+    > If it says `Connection refused`, turn on "Enable host-side TCP support" option in [Docker Desktop Settings](https://docs.docker.com/ai/model-runner/get-started/#docker-desktop).
 
 1. Download the model. The default model OCP uses is [ai/smollm2](https://hub.docker.com/r/ai/smollm2).
 
@@ -74,13 +76,27 @@ This page describes how to run OpenChat Playground (OCP) with [Docker Model Runn
 
 ## Run in local container
 
-1. Make sure the Docker Model Runner is up and running with the following command.
+1. Make sure the Docker Model Runner is up and ready to accept requests with the following command.
 
     ```bash
     docker model status
     ```
 
    It should say `Docker Model Runner is running`.
+
+    ```bash
+    # bash/zsh
+    curl http://localhost:12434
+    ```
+
+    ```powershell
+    # {owershell
+    Invoke-WebRequest http://localhost:12434
+    ```
+
+    It should say `The Service is running`
+
+    > If it says `Connection refused`, turn on "Enable host-side TCP support" option in [Docker Desktop Settings](https://docs.docker.com/ai/model-runner/get-started/#docker-desktop).
 
 1. Download the model. The default model OCP uses is [ai/smollm2](https://hub.docker.com/r/ai/smollm2).
 

--- a/docs/docker-model-runner.md
+++ b/docs/docker-model-runner.md
@@ -18,7 +18,7 @@ This page describes how to run OpenChat Playground (OCP) with [Docker Model Runn
 
 ## Run on local machine
 
-1. Make sure the Docker Model Runner is up and ready to accept requests with the following command.
+1. Make sure the Docker Model Runner is up and running, and ready to accept requests with the following command.
 
     ```bash
     docker model status
@@ -76,7 +76,7 @@ This page describes how to run OpenChat Playground (OCP) with [Docker Model Runn
 
 ## Run in local container
 
-1. Make sure the Docker Model Runner is up and ready to accept requests with the following command.
+1. Make sure the Docker Model Runner is up and running, and ready to accept requests with the following command.
 
     ```bash
     docker model status


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->

* Docker Desktop에서 특정 옵션을 비활성화하면, Docker Model Runner Connector로 앱을 기동후 아래와 같이 Connection refused 예외 발생
* Docker Model Runner 가이드 문서에서 해당 옵션 확인, 활성화하는 방법을 추가 
```bash
fail: Microsoft.Extensions.AI.LoggingChatClient[1784604714]
      GetStreamingResponseAsync failed.
      System.AggregateException: Retry failed after 4 tries. (Connection refused (localhost:12434)) (Connection refused (localhost:12434)) (Connection refused (localhost:12434)) (Connection refused (localhost:12434))
```

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] New feature
[ ] Refactoring (no functional changes, no api changes)
[x] Documentation content changes
[ ] Other... Please describe:
```

## README updated?
<!-- Mark one with an "x". -->
```
[ ] Yes
[ ] No
[x] N/A
```

## How to Test
* "Enable host-side TCP support" 비활성화
  * bash `curl` 요청시 : `Couldn't connect to server`
  * pwsh `Invoke-WebRequest` 요청시 : `Connection refused`

<img width="1448" height="872" alt="image" src="https://github.com/user-attachments/assets/86902980-dc7c-41da-82c8-0c78ff99a49b" />

> curl

<img width="1440" height="871" alt="image" src="https://github.com/user-attachments/assets/97a113e2-d7e7-46b9-b4a2-6eb21a9b8cec" />

> powershell

* "Enable host-side TCP support" 활성화
  * bash `curl` 요청시 : `The Service is running`
  * pwsh `Invoke-WebRequest` 요청시 : `The Service is running`

<img width="1442" height="868" alt="image" src="https://github.com/user-attachments/assets/f3dd2c85-49ef-4d60-9918-78741a15303a" />

> curl

<img width="1454" height="871" alt="image" src="https://github.com/user-attachments/assets/9d44af94-713b-48bd-a797-63c30ff5db15" />

> powershell
